### PR TITLE
Refactors to make subscription updating easier to reason about and transaction support

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,5 @@ parameters:
 	level: 8
 	paths:
 		- src
+	ignoreErrors:
+		- '#Access to an undefined property Braintree\\Transaction::\$addOns#'

--- a/src/Contracts/SubscriptionGateway.php
+++ b/src/Contracts/SubscriptionGateway.php
@@ -2,6 +2,7 @@
 
 namespace TeamGantt\Dues\Contracts;
 
+use DateTime;
 use TeamGantt\Dues\Model\Customer;
 use TeamGantt\Dues\Model\PaymentMethod;
 use TeamGantt\Dues\Model\Plan;
@@ -9,6 +10,7 @@ use TeamGantt\Dues\Model\Subscription;
 use TeamGantt\Dues\Model\Subscription\AddOn;
 use TeamGantt\Dues\Model\Subscription\Discount;
 use TeamGantt\Dues\Model\Subscription\Status;
+use TeamGantt\Dues\Model\Transaction;
 
 interface SubscriptionGateway
 {
@@ -43,6 +45,11 @@ interface SubscriptionGateway
     public function findSubscriptionsByCustomerId(string $customerId, array $statuses = []): array;
 
     public function findSubscriptionById(string $subscriptionId): ?Subscription;
+
+    /**
+     * @return Transaction[]
+     */
+    public function findTransactionsByCustomerId(string $customerId, ?DateTime $start = null, ?DateTime $end = null): array;
 
     /**
      * @return AddOn[]

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -32,6 +32,11 @@ class Subscription extends Entity implements Arrayable
 
     protected Modifiers $discounts;
 
+    /**
+     * @var Transaction[]
+     */
+    protected array $transactions = [];
+
     public function __construct(string $id = '')
     {
         parent::__construct($id);
@@ -382,5 +387,34 @@ class Subscription extends Entity implements Arrayable
         }
 
         return $modifierDefaults;
+    }
+
+    /**
+     * @return Transaction[]
+     */
+    public function getTransactions(): array
+    {
+        return $this->transactions;
+    }
+
+    /**
+     * Set the value of transactions.
+     *
+     * @param Transaction[] $transactions
+     *
+     * @return Subscription
+     */
+    public function setTransactions(array $transactions): self
+    {
+        $this->transactions = $transactions;
+
+        return $this;
+    }
+
+    public function addTransaction(Transaction $transaction): self
+    {
+        $this->transactions[] = $transaction;
+
+        return $this;
     }
 }

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -276,6 +276,14 @@ class Subscription extends Entity implements Arrayable
         return $this;
     }
 
+    /**
+     * @return Subscription
+     */
+    public function cancel(): self
+    {
+        return $this->setStatus(Status::canceled());
+    }
+
     public function getCustomer(): Customer
     {
         return $this->customer;

--- a/src/Model/Transaction.php
+++ b/src/Model/Transaction.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace TeamGantt\Dues\Model;
+
+use DateTime;
+use DateTimeZone;
+use TeamGantt\Dues\Model\Plan\NullPlan;
+use TeamGantt\Dues\Model\Subscription\AddOn;
+use TeamGantt\Dues\Model\Subscription\Discount;
+use TeamGantt\Dues\Model\Transaction\Status;
+use TeamGantt\Dues\Model\Transaction\Type;
+
+class Transaction extends Entity
+{
+    protected Subscription $subscription;
+
+    protected Customer $customer;
+
+    protected string $companyName = '';
+
+    protected Plan $plan;
+
+    /**
+     * @var AddOn[]
+     */
+    protected array $addOns = [];
+
+    /**
+     * @var Discount[]
+     */
+    protected array $discounts = [];
+
+    protected Money $amount;
+
+    protected Type $type;
+
+    protected Status $status;
+
+    protected DateTime $createdAt;
+
+    public function __construct(string $id = '', Subscription $subscription)
+    {
+        parent::__construct($id);
+        $this->subscription = $subscription;
+        $this->plan = new NullPlan();
+        $this->amount = new Money(0.00);
+        $this->type = Type::initialized();
+        $this->status = Status::initialized();
+        $this->createdAt = new DateTime('now', new DateTimeZone('UTC'));
+    }
+
+    public function getCreatedAt(): DateTime
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @return Transaction
+     */
+    public function setCreatedAt(DateTime $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getStatus(): Status
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return Transaction
+     */
+    public function setStatus(Status $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getType(): Type
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return Transaction
+     */
+    public function setType(Type $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getAmount(): Money
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @return Transaction
+     */
+    public function setAmount(Money $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    /**
+     * @return Discount[]
+     */
+    public function getDiscounts(): array
+    {
+        return $this->discounts;
+    }
+
+    /**
+     * @param Discount[] $discounts
+     *
+     * @return Transaction
+     */
+    public function setDiscounts(array $discounts): self
+    {
+        $this->discounts = $discounts;
+
+        return $this;
+    }
+
+    /**
+     * @return AddOn[]
+     */
+    public function getAddOns(): array
+    {
+        return $this->addOns;
+    }
+
+    /**
+     * @param AddOn[] $addOns
+     *
+     * @return Transaction
+     */
+    public function setAddOns(array $addOns): self
+    {
+        $this->addOns = $addOns;
+
+        return $this;
+    }
+
+    public function getPlan(): Plan
+    {
+        return $this->plan;
+    }
+
+    /**
+     * @return Transaction
+     */
+    public function setPlan(Plan $plan): self
+    {
+        $this->plan = $plan;
+
+        return $this;
+    }
+
+    public function getSubscription(): Subscription
+    {
+        return $this->subscription;
+    }
+
+    /**
+     * @return Transaction
+     */
+    public function setSubscription(Subscription $subscription): self
+    {
+        $this->subscription = $subscription;
+
+        return $this;
+    }
+
+    public function getCustomer(): Customer
+    {
+        return $this->customer;
+    }
+
+    /**
+     * @return Transaction
+     */
+    public function setCustomer(Customer $customer): self
+    {
+        $this->customer = $customer;
+
+        return $this;
+    }
+}

--- a/src/Model/Transaction/Status.php
+++ b/src/Model/Transaction/Status.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TeamGantt\Dues\Model\Transaction;
+
+use Spatie\Enum\Enum;
+
+/**
+ * @method static self authorizationExpired()
+ * @method static self authorized()
+ * @method static self authorizing()
+ * @method static self settlementConfirmed()
+ * @method static self settlementPending()
+ * @method static self settlementDeclined()
+ * @method static self failed()
+ * @method static self gatewayRejected()
+ * @method static self processorDeclined()
+ * @method static self settled()
+ * @method static self settling()
+ * @method static self submittedForSettlement()
+ * @method static self voided()
+ * @method static self unrecognized()
+ * @method static self initialized()
+ */
+class Status extends Enum
+{
+}

--- a/src/Model/Transaction/Type.php
+++ b/src/Model/Transaction/Type.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TeamGantt\Dues\Model\Transaction;
+
+use Spatie\Enum\Enum;
+
+/**
+ * @method static self sale()
+ * @method static self credit()
+ * @method static self initialized()
+ */
+class Type extends Enum
+{
+}

--- a/src/Processor/Braintree.php
+++ b/src/Processor/Braintree.php
@@ -28,12 +28,12 @@ use TeamGantt\Dues\Model\Price\NullPrice;
 use TeamGantt\Dues\Model\Subscription;
 use TeamGantt\Dues\Model\Subscription\Status;
 use TeamGantt\Dues\Model\Subscription\SubscriptionBuilder;
-use TeamGantt\Dues\Processor\Braintree\AddOnMapper;
-use TeamGantt\Dues\Processor\Braintree\CustomerMapper;
-use TeamGantt\Dues\Processor\Braintree\DiscountMapper;
-use TeamGantt\Dues\Processor\Braintree\PaymentMethodMapper;
-use TeamGantt\Dues\Processor\Braintree\PlanMapper;
-use TeamGantt\Dues\Processor\Braintree\SubscriptionMapper;
+use TeamGantt\Dues\Processor\Braintree\Mapper\AddOnMapper;
+use TeamGantt\Dues\Processor\Braintree\Mapper\CustomerMapper;
+use TeamGantt\Dues\Processor\Braintree\Mapper\DiscountMapper;
+use TeamGantt\Dues\Processor\Braintree\Mapper\PaymentMethodMapper;
+use TeamGantt\Dues\Processor\Braintree\Mapper\PlanMapper;
+use TeamGantt\Dues\Processor\Braintree\Mapper\SubscriptionMapper;
 
 class Braintree implements SubscriptionGateway
 {

--- a/src/Processor/Braintree/Mapper/AddOnMapper.php
+++ b/src/Processor/Braintree/Mapper/AddOnMapper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TeamGantt\Dues\Processor\Braintree;
+namespace TeamGantt\Dues\Processor\Braintree\Mapper;
 
 use Braintree;
 use TeamGantt\Dues\Model\Subscription\AddOn;

--- a/src/Processor/Braintree/Mapper/CustomerMapper.php
+++ b/src/Processor/Braintree/Mapper/CustomerMapper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TeamGantt\Dues\Processor\Braintree;
+namespace TeamGantt\Dues\Processor\Braintree\Mapper;
 
 use Braintree;
 use TeamGantt\Dues\Arr;

--- a/src/Processor/Braintree/Mapper/DiscountMapper.php
+++ b/src/Processor/Braintree/Mapper/DiscountMapper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TeamGantt\Dues\Processor\Braintree;
+namespace TeamGantt\Dues\Processor\Braintree\Mapper;
 
 use Braintree;
 use TeamGantt\Dues\Model\Subscription\Discount;

--- a/src/Processor/Braintree/Mapper/MapsModifiers.php
+++ b/src/Processor/Braintree/Mapper/MapsModifiers.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TeamGantt\Dues\Processor\Braintree;
+namespace TeamGantt\Dues\Processor\Braintree\Mapper;
 
 use Braintree\AddOn;
 use Braintree\Discount;

--- a/src/Processor/Braintree/Mapper/PaymentMethodMapper.php
+++ b/src/Processor/Braintree/Mapper/PaymentMethodMapper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TeamGantt\Dues\Processor\Braintree;
+namespace TeamGantt\Dues\Processor\Braintree\Mapper;
 
 use InvalidArgumentException;
 use TeamGantt\Dues\Arr;

--- a/src/Processor/Braintree/Mapper/PlanMapper.php
+++ b/src/Processor/Braintree/Mapper/PlanMapper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TeamGantt\Dues\Processor\Braintree;
+namespace TeamGantt\Dues\Processor\Braintree\Mapper;
 
 use Braintree\Plan as BraintreePlan;
 use TeamGantt\Dues\Model\Plan;

--- a/src/Processor/Braintree/Mapper/SubscriptionMapper.php
+++ b/src/Processor/Braintree/Mapper/SubscriptionMapper.php
@@ -20,10 +20,16 @@ class SubscriptionMapper
 
     private DiscountMapper $discountMapper;
 
-    public function __construct(AddOnMapper $addOnMapper, DiscountMapper $discountMapper)
-    {
+    private TransactionMapper $transactionMapper;
+
+    public function __construct(
+        AddOnMapper $addOnMapper,
+        DiscountMapper $discountMapper,
+        TransactionMapper $transactionMapper
+    ) {
         $this->addOnMapper = $addOnMapper;
         $this->discountMapper = $discountMapper;
+        $this->transactionMapper = $transactionMapper;
     }
 
     /**
@@ -105,6 +111,10 @@ class SubscriptionMapper
             ->withPaymentMethod($paymentMethod)
             ->withPlan($plan)
             ->build();
+
+        foreach ($result->transactions as $transaction) {
+            $subscription->addTransaction($this->transactionMapper->fromResult($transaction));
+        }
 
         $subscription->setAddOns(new Modifiers($subscription, $addOns));
 

--- a/src/Processor/Braintree/Mapper/SubscriptionMapper.php
+++ b/src/Processor/Braintree/Mapper/SubscriptionMapper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TeamGantt\Dues\Processor\Braintree;
+namespace TeamGantt\Dues\Processor\Braintree\Mapper;
 
 use Braintree;
 use TeamGantt\Dues\Arr;

--- a/src/Processor/Braintree/Mapper/TransactionMapper.php
+++ b/src/Processor/Braintree/Mapper/TransactionMapper.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Mapper;
+
+use Braintree\Transaction as BraintreeTransaction;
+use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\Money;
+use TeamGantt\Dues\Model\Plan;
+use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Model\Transaction;
+use TeamGantt\Dues\Model\Transaction\Status;
+use TeamGantt\Dues\Model\Transaction\Type;
+
+class TransactionMapper
+{
+    private AddOnMapper $addOnMapper;
+
+    private DiscountMapper $discountMapper;
+
+    public function __construct(
+        AddOnMapper $addOnMapper,
+        DiscountMapper $discountMapper
+    ) {
+        $this->addOnMapper = $addOnMapper;
+        $this->discountMapper = $discountMapper;
+    }
+
+    public function fromResult(BraintreeTransaction $result): Transaction
+    {
+        $subscription = new Subscription($result->subscriptionId);
+        $transaction = new Transaction($result->id, $subscription);
+
+        return $transaction
+            ->setStatus($this->getStatus($result))
+            ->setAmount(new Money(floatval($result->amount)))
+            ->setCustomer($this->getCustomer($result))
+            ->setCreatedAt($result->createdAt)
+            ->setAddOns($this->addOnMapper->fromResults($result->addOns))
+            ->setDiscounts($this->discountMapper->fromResults($result->discounts))
+            ->setPlan(new Plan($result->planId))
+            ->setType($this->getType($result));
+    }
+
+    private function getCustomer(BraintreeTransaction $result): Customer
+    {
+        $details = $result->customerDetails;
+        $customer = new Customer($details->id);
+
+        return $customer
+            ->setEmailAddress($details->email)
+            ->setFirstName($details->firstName)
+            ->setLastName($details->lastName);
+    }
+
+    private function getType(BraintreeTransaction $result): Type
+    {
+        if (BraintreeTransaction::SALE === $result->type) {
+            return Type::sale();
+        }
+
+        return Type::credit();
+    }
+
+    private function getStatus(BraintreeTransaction $result): Status
+    {
+        $status = $result->status;
+        switch ($status) {
+            case BraintreeTransaction::AUTHORIZATION_EXPIRED:
+                return Status::authorizationExpired();
+            case BraintreeTransaction::AUTHORIZED:
+                return Status::authorized();
+            case BraintreeTransaction::AUTHORIZING:
+                return Status::authorizing();
+            case BraintreeTransaction::SETTLEMENT_PENDING:
+                return Status::settlementPending();
+            case BraintreeTransaction::SETTLEMENT_DECLINED:
+                return Status::settlementDeclined();
+            case BraintreeTransaction::FAILED:
+                return Status::failed();
+            case BraintreeTransaction::GATEWAY_REJECTED:
+                return Status::gatewayRejected();
+            case BraintreeTransaction::PROCESSOR_DECLINED:
+                return Status::processorDeclined();
+            case BraintreeTransaction::SETTLED:
+                return Status::settled();
+            case BraintreeTransaction::SETTLING:
+                return Status::settling();
+            case BraintreeTransaction::SUBMITTED_FOR_SETTLEMENT:
+                return Status::submittedForSettlement();
+            case BraintreeTransaction::VOIDED:
+                return Status::voided();
+            case BraintreeTransaction::SETTLEMENT_CONFIRMED:
+                return Status::settlementConfirmed();
+            default:
+                return Status::unrecognized();
+        }
+    }
+}

--- a/src/Processor/Braintree/Repository/AddOnRepository.php
+++ b/src/Processor/Braintree/Repository/AddOnRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Repository;
+
+use Braintree\Gateway;
+use TeamGantt\Dues\Model\Subscription\AddOn;
+use TeamGantt\Dues\Processor\Braintree\Mapper\AddOnMapper;
+
+class AddOnRepository
+{
+    protected AddOnMapper $mapper;
+
+    private Gateway $braintree;
+
+    public function __construct(Gateway $braintree, AddOnMapper $mapper)
+    {
+        $this->braintree = $braintree;
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * @return AddOn[]
+     */
+    public function all(): array
+    {
+        $results = $this
+            ->braintree
+            ->addOn()
+            ->all();
+
+        return $this->mapper->fromResults($results);
+    }
+}

--- a/src/Processor/Braintree/Repository/CustomerRepository.php
+++ b/src/Processor/Braintree/Repository/CustomerRepository.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Repository;
+
+use Braintree\Customer as BraintreeCustomer;
+use Braintree\Gateway;
+use Exception;
+use TeamGantt\Dues\Exception\CustomerNotCreatedException;
+use TeamGantt\Dues\Exception\CustomerNotDeletedException;
+use TeamGantt\Dues\Exception\CustomerNotUpdatedException;
+use TeamGantt\Dues\Exception\InvariantException;
+use TeamGantt\Dues\Exception\UnknownException;
+use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\PaymentMethod;
+use TeamGantt\Dues\Processor\Braintree\Mapper\CustomerMapper;
+
+class CustomerRepository
+{
+    protected CustomerMapper $mapper;
+
+    protected PaymentMethodRepository $paymentMethods;
+
+    private Gateway $braintree;
+
+    public function __construct(
+        Gateway $braintree,
+        CustomerMapper $mapper,
+        PaymentMethodRepository $paymentMethods
+    ) {
+        $this->braintree = $braintree;
+        $this->mapper = $mapper;
+        $this->paymentMethods = $paymentMethods;
+    }
+
+    public function add(Customer $customer): Customer
+    {
+        $request = $this->mapper->toRequest($customer);
+
+        $result = $this
+            ->braintree
+            ->customer()
+            ->create($request);
+
+        if (!$result->success) {
+            $message = isset($result->message) ? $result->message : 'Unknown message';
+            throw new CustomerNotCreatedException($message);
+        }
+
+        if (!isset($result->customer)) {
+            throw new InvariantException('Result has no customer property');
+        }
+
+        $newCustomer = $this->mapper->fromResult($result->customer);
+
+        $newMethods = array_reduce(
+            $customer->getPaymentMethods(),
+            fn (array $r, PaymentMethod $m) => [...$r, $this->paymentMethods->add($m->setCustomer($newCustomer))],
+            []
+        );
+
+        return $newCustomer->setPaymentMethods($newMethods);
+    }
+
+    public function update(Customer $customer): Customer
+    {
+        if ($customer->isNew()) {
+            throw new CustomerNotUpdatedException('Cannot update a new customer');
+        }
+
+        // Create any new payment methods
+        $allPaymentMethods = $customer->getPaymentMethods();
+        $paymentMethods = [];
+        foreach ($allPaymentMethods as $paymentMethod) {
+            if ($paymentMethod->isNew()) {
+                $paymentMethods[] = ($this->paymentMethods->add($paymentMethod))->setIsDefaultPaymentMethod($paymentMethod->isDefaultPaymentMethod());
+            } else {
+                $paymentMethods[] = $paymentMethod;
+            }
+        }
+        $customer->setPaymentMethods($paymentMethods);
+
+        $id = $customer->getId();
+
+        // Update the user @todo rollback payment methods
+        $request = $this->mapper->toRequest($customer);
+        $result = $this
+            ->braintree
+            ->customer()
+            ->update($id, $request);
+
+        if (!$result->success) {
+            $message = isset($result->message) ? $result->message : 'Unknown message';
+            throw new CustomerNotUpdatedException($message);
+        }
+
+        $customer = $this->find($id);
+        if (null === $customer) {
+            throw new UnknownException('Could not find updated customer');
+        }
+
+        return $customer;
+    }
+
+    public function remove(string $id): void
+    {
+        try {
+            $result = $this->braintree->customer()->delete($id);
+            if (!$result->success) {
+                $message = isset($result->message) ? $result->message : 'Unknown message';
+                throw new CustomerNotDeletedException($message);
+            }
+        } catch (Exception $e) {
+            throw new CustomerNotDeletedException($e->getMessage());
+        }
+    }
+
+    public function find(string $id): ?Customer
+    {
+        if ($customerResult = $this->findBraintreeCustomer($id)) {
+            return $this->mapper->fromResult($customerResult);
+        }
+
+        return null;
+    }
+
+    public function findBraintreeCustomer(string $customerId): ?BraintreeCustomer
+    {
+        try {
+            $result = $this
+                ->braintree
+                ->customer()
+                ->find($customerId);
+
+            if (is_bool($result)) {
+                throw new UnknownException('Customer find request failed');
+            }
+
+            return $result;
+        } catch (UnknownException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+}

--- a/src/Processor/Braintree/Repository/DiscountRepository.php
+++ b/src/Processor/Braintree/Repository/DiscountRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Repository;
+
+use Braintree\Gateway;
+use TeamGantt\Dues\Model\Subscription\Discount;
+use TeamGantt\Dues\Processor\Braintree\Mapper\DiscountMapper;
+
+class DiscountRepository
+{
+    protected DiscountMapper $mapper;
+
+    private Gateway $braintree;
+
+    public function __construct(Gateway $braintree, DiscountMapper $mapper)
+    {
+        $this->braintree = $braintree;
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * @return Discount[]
+     */
+    public function all(): array
+    {
+        $results = $this
+            ->braintree
+            ->discount()
+            ->all();
+
+        return $this->mapper->fromResults($results);
+    }
+}

--- a/src/Processor/Braintree/Repository/PaymentMethodRepository.php
+++ b/src/Processor/Braintree/Repository/PaymentMethodRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Repository;
+
+use Braintree\Gateway;
+use TeamGantt\Dues\Exception\PaymentMethodNotCreatedException;
+use TeamGantt\Dues\Model\PaymentMethod;
+use TeamGantt\Dues\Model\PaymentMethod\Token;
+use TeamGantt\Dues\Processor\Braintree\Mapper\PaymentMethodMapper;
+
+class PaymentMethodRepository
+{
+    protected PaymentMethodMapper $mapper;
+
+    private Gateway $braintree;
+
+    public function __construct(Gateway $braintree, PaymentMethodMapper $mapper)
+    {
+        $this->braintree = $braintree;
+        $this->mapper = $mapper;
+    }
+
+    public function add(PaymentMethod $paymentMethod): Token
+    {
+        $request = $this->mapper->toRequest($paymentMethod);
+
+        $result = $this
+            ->braintree
+            ->paymentMethod()
+            ->create($request);
+
+        if (!$result->success) {
+            throw new PaymentMethodNotCreatedException($result->message);
+        }
+
+        return $this->mapper->fromResult($result->paymentMethod);
+    }
+}

--- a/src/Processor/Braintree/Repository/PlanRepository.php
+++ b/src/Processor/Braintree/Repository/PlanRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Repository;
+
+use Braintree\Gateway;
+use TeamGantt\Dues\Model\Plan;
+use TeamGantt\Dues\Processor\Braintree\Mapper\PlanMapper;
+
+class PlanRepository
+{
+    protected PlanMapper $mapper;
+
+    private Gateway $braintree;
+
+    public function __construct(Gateway $braintree, PlanMapper $mapper)
+    {
+        $this->braintree = $braintree;
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * @return Plan[]
+     */
+    public function all(): array
+    {
+        $results = $this
+            ->braintree
+            ->plan()
+            ->all();
+
+        return array_reduce($results, function ($r, $i) {
+            $plan = $this->mapper->fromResult($i);
+
+            return [...$r, $plan];
+        }, []);
+    }
+
+    public function find(string $id): ?Plan
+    {
+        $plans = $this->all();
+
+        foreach ($plans as $plan) {
+            if ($plan->getId() === $id) {
+                return $plan;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Processor/Braintree/Repository/SubscriptionRepository.php
+++ b/src/Processor/Braintree/Repository/SubscriptionRepository.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Repository;
+
+use Braintree\Gateway;
+use Exception;
+use TeamGantt\Dues\Arr;
+use TeamGantt\Dues\Exception\SubscriptionNotCreatedException;
+use TeamGantt\Dues\Exception\UnknownException;
+use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Model\Subscription\Status;
+use TeamGantt\Dues\Processor\Braintree\Mapper\SubscriptionMapper;
+use TeamGantt\Dues\Processor\Braintree\Subscription\Update\UpdateStrategyFactory;
+
+class SubscriptionRepository
+{
+    protected CustomerRepository $customers;
+
+    protected PlanRepository $plans;
+
+    protected SubscriptionMapper $mapper;
+
+    private Gateway $braintree;
+
+    private UpdateStrategyFactory $strategies;
+
+    public function __construct(
+        Gateway $braintree,
+        SubscriptionMapper $mapper,
+        CustomerRepository $customers,
+        PlanRepository $plans)
+    {
+        $this->braintree = $braintree;
+        $this->mapper = $mapper;
+        $this->customers = $customers;
+        $this->plans = $plans;
+        $this->strategies = new UpdateStrategyFactory($this->braintree, $this->mapper, $this, $plans);
+    }
+
+    public function add(Subscription $subscription): Subscription
+    {
+        $customer = $subscription->getCustomer();
+        $isNewCustomer = false;
+
+        $plan = $subscription->getPlan();
+        $plan = $this->plans->find($plan->getId());
+
+        if (null === $plan) {
+            throw new SubscriptionNotCreatedException('Failed to fetch subscription plan');
+        }
+
+        $subscription->setPlan($plan);
+
+        if ($customer->isNew()) {
+            $isNewCustomer = true;
+            $subscription->setCustomer($this->customers->add($customer));
+        }
+
+        $request = $this->mapper->toRequest($subscription);
+        $request = Arr::dissoc($request, ['id', 'status']);
+
+        $result = $this
+            ->braintree
+            ->subscription()
+            ->create($request);
+
+        if ($result->success) {
+            $newSubscription = $this->mapper->fromResult($result->subscription);
+
+            return $newSubscription
+                ->setCustomer($subscription->getCustomer())
+                ->resetPlan($plan);
+        }
+
+        if (!$isNewCustomer) {
+            throw new SubscriptionNotCreatedException($result->message);
+        }
+
+        throw new SubscriptionNotCreatedException($result->message, $subscription->getCustomer());
+    }
+
+    public function find(string $id): ?Subscription
+    {
+        try {
+            $result = $this
+                ->braintree
+                ->subscription()
+                ->find($id);
+
+            return $this->mapper->fromResult($result);
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+
+    public function update(Subscription $subscription): Subscription
+    {
+        $strategy = $this->strategies->createStrategy($subscription);
+
+        if ($updated = $strategy->update($subscription)) {
+            return $updated;
+        }
+
+        $updated = $this->find($subscription->getId());
+        if (null === $updated) {
+            throw new UnknownException('Updated subscription not found');
+        }
+
+        return $updated;
+    }
+
+    /**
+     * @param Status[] $statuses
+     *
+     * @return Subscription[]
+     */
+    public function findByCustomerId(string $customerId, array $statuses = []): array
+    {
+        $customerResult = $this->customers->findBraintreeCustomer($customerId);
+
+        if (null === $customerResult) {
+            return [];
+        }
+
+        $subscriptions = Arr::mapcat($customerResult->paymentMethods, function ($pm) {
+            return array_map([$this->mapper, 'fromResult'], $pm->subscriptions);
+        });
+
+        if (empty($statuses)) {
+            return $subscriptions;
+        }
+
+        return array_values(array_filter($subscriptions, fn (Subscription $sub) => in_array($sub->getStatus(), $statuses)));
+    }
+}

--- a/src/Processor/Braintree/Repository/TransactionRepository.php
+++ b/src/Processor/Braintree/Repository/TransactionRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Repository;
+
+use Braintree\Gateway;
+use Braintree\TransactionSearch;
+use DateTime;
+use TeamGantt\Dues\Model\Transaction;
+use TeamGantt\Dues\Processor\Braintree\Mapper\TransactionMapper;
+
+class TransactionRepository
+{
+    protected TransactionMapper $mapper;
+
+    private Gateway $braintree;
+
+    const DATE_FORMAT = 'm/d/Y H:i';
+
+    public function __construct(Gateway $braintree, TransactionMapper $mapper)
+    {
+        $this->braintree = $braintree;
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * @return Transaction[]
+     */
+    public function findByCustomerId(string $customerId, ?DateTime $start = null, ?DateTime $end = null): array
+    {
+        $criteria = [TransactionSearch::customerId()->is($customerId)];
+
+        if (null !== $start) {
+            $criteria[] = TransactionSearch::createdAt()->greaterThanOrEqualTo($start->format(self::DATE_FORMAT));
+        }
+
+        if (null !== $end) {
+            $criteria[] = TransactionSearch::createdAt()->lessThanOrEqualTo($end->format(self::DATE_FORMAT));
+        }
+
+        $collection = $this->braintree->transaction()->search($criteria);
+
+        $mapped = [];
+        foreach ($collection as $transaction) {
+            $mapped[] = $this->mapper->fromResult($transaction);
+        }
+
+        return $mapped;
+    }
+}

--- a/src/Processor/Braintree/Subscription/Update/BaseUpdateStrategy.php
+++ b/src/Processor/Braintree/Subscription/Update/BaseUpdateStrategy.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Subscription\Update;
+
+use Braintree\Gateway;
+use Braintree\Result\Error;
+use Braintree\Result\Successful;
+use TeamGantt\Dues\Arr;
+use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Processor\Braintree\Mapper\SubscriptionMapper;
+use TeamGantt\Dues\Processor\Braintree\Repository\PlanRepository;
+use TeamGantt\Dues\Processor\Braintree\Repository\SubscriptionRepository;
+
+abstract class BaseUpdateStrategy implements UpdateStrategy
+{
+    protected Gateway $braintree;
+
+    protected SubscriptionMapper $mapper;
+
+    protected SubscriptionRepository $subscriptions;
+
+    protected PlanRepository $plans;
+
+    public function __construct(
+        Gateway $braintree,
+        SubscriptionMapper $mapper,
+        SubscriptionRepository $subscriptions,
+        PlanRepository $plans)
+    {
+        $this->braintree = $braintree;
+        $this->mapper = $mapper;
+        $this->subscriptions = $subscriptions;
+        $this->plans = $plans;
+    }
+
+    /**
+     * @return Successful|Error
+     */
+    protected function doBraintreeUpdate(Subscription $subscription)
+    {
+        $request = $this->mapper->toRequest($subscription);
+        $request = Arr::dissoc($request, ['firstBillingDate', 'status']);
+        $request['options'] = ['prorateCharges' => true];
+
+        return $this
+            ->braintree
+            ->subscription()
+            ->update($request['id'], $request);
+    }
+}

--- a/src/Processor/Braintree/Subscription/Update/CancelStrategy.php
+++ b/src/Processor/Braintree/Subscription/Update/CancelStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Subscription\Update;
+
+use Exception;
+use TeamGantt\Dues\Exception\SubscriptionNotCanceledException;
+use TeamGantt\Dues\Model\Subscription;
+
+class CancelStrategy extends BaseUpdateStrategy
+{
+    public function update(Subscription $subscription): ?Subscription
+    {
+        try {
+            $this
+                ->braintree
+                ->subscription()
+                ->cancel($subscription->getId());
+
+            return null;
+        } catch (Exception $e) {
+            throw new SubscriptionNotCanceledException($e->getMessage());
+        }
+    }
+}

--- a/src/Processor/Braintree/Subscription/Update/ChangeBillingCycleStrategy.php
+++ b/src/Processor/Braintree/Subscription/Update/ChangeBillingCycleStrategy.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Subscription\Update;
+
+use TeamGantt\Dues\Exception\SubscriptionNotUpdatedException;
+use TeamGantt\Dues\Exception\UnknownException;
+use TeamGantt\Dues\Model\Price;
+use TeamGantt\Dues\Model\Price\NullPrice;
+use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Model\Subscription\Discount;
+use TeamGantt\Dues\Model\Subscription\SubscriptionBuilder;
+
+class ChangeBillingCycleStrategy extends BaseUpdateStrategy
+{
+    public function update(Subscription $subscription): ?Subscription
+    {
+        // Zero out and cancel the subscription in order to get a balance
+        $canceled = $this->cancel($subscription);
+
+        // Make a new subscription to replace old one
+        $newSubscription = $this->createReplacementSubscription($subscription, $canceled);
+
+        // Update the state of the given subscription to reflect canceled state
+        $subscription->merge($canceled);
+
+        // Save and return the new replacement subscription
+        return $this->subscriptions->add($newSubscription);
+    }
+
+    private function createReplacementSubscription(Subscription $original, Subscription $canceled): Subscription
+    {
+        // Purchase new subscription, applying balance from previous subscription.
+        $builder = (new SubscriptionBuilder())
+                ->withPlan($original->getPlan())
+                ->withCustomer($original->getCustomer())
+                ->withDiscounts($original->getDiscounts()->getAll())
+                ->withAddOns($original->getAddOns()->getAll());
+
+        if ($balance = $canceled->getBalance()) {
+            $balanceDiscount = new Discount('balance', 1, new Price(abs($balance->getAmount())));
+
+            $builder->withDiscount($balanceDiscount);
+        }
+
+        if (!empty($original->getPrice())) {
+            $builder->withPrice($original->getPrice());
+        }
+
+        $newSubscription = $builder->build();
+
+        $discounts = $newSubscription->getDiscounts();
+        $addOns = $newSubscription->getAddOns();
+
+        return $newSubscription
+            ->merge($canceled)
+            ->setCustomer($original->getCustomer())
+            ->setAddOns($addOns)
+            ->setDiscounts($discounts);
+    }
+
+    private function cancel(Subscription $original): Subscription
+    {
+        // Close out the subscription, removing any price information
+        $clone = (new Subscription($original->getId()))->merge($original);
+        $subscription = $clone->closeOut();
+        $result = $this->doBraintreeUpdate($subscription);
+
+        if (!$result->success) {
+            $message = isset($result->message) ? $result->message : 'An unknown update error occurred';
+            throw new SubscriptionNotUpdatedException($message);
+        }
+        $updated = $this->subscriptions->find($subscription->getId());
+
+        if (null === $updated) {
+            throw new UnknownException('Failed to fetch updated subscription');
+        }
+
+        // Cancel subscription
+        return $this->subscriptions->update($updated->cancel())
+            ->closeOut()
+            ->setPrice(new NullPrice());
+    }
+}

--- a/src/Processor/Braintree/Subscription/Update/DefaultUpdateStrategy.php
+++ b/src/Processor/Braintree/Subscription/Update/DefaultUpdateStrategy.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Subscription\Update;
+
+use Braintree\Error\Codes;
+use Braintree\Gateway;
+use Braintree\Result\Error;
+use Braintree\Result\Successful;
+use Exception;
+use TeamGantt\Dues\Exception\SubscriptionNotUpdatedException;
+use TeamGantt\Dues\Exception\UnknownException;
+use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Processor\Braintree\Mapper\SubscriptionMapper;
+use TeamGantt\Dues\Processor\Braintree\Repository\PlanRepository;
+use TeamGantt\Dues\Processor\Braintree\Repository\SubscriptionRepository;
+
+class DefaultUpdateStrategy extends BaseUpdateStrategy
+{
+    private ChangeBillingCycleStrategy $changeBillingCycleStrategy;
+
+    public function __construct(
+        Gateway $braintree,
+        SubscriptionMapper $mapper,
+        SubscriptionRepository $subscriptions,
+        PlanRepository $plans,
+        ChangeBillingCycleStrategy $changeBillingCycleStrategy
+    ) {
+        parent::__construct($braintree, $mapper, $subscriptions, $plans);
+        $this->changeBillingCycleStrategy = $changeBillingCycleStrategy;
+    }
+
+    public function update(Subscription $subscription): ?Subscription
+    {
+        try {
+            $result = $this->doBraintreeUpdate($subscription);
+
+            if ($this->isBillingFrequencyError($result)) {
+                return $this->changeBillingCycleStrategy->update($subscription);
+            }
+
+            if ($result instanceof Error) {
+                $message = isset($result->message) ? $result->message : 'An unknown update error occurred';
+                throw new SubscriptionNotUpdatedException($message);
+            }
+
+            $updated = $this->subscriptions->find($subscription->getId());
+
+            if (null == $updated) {
+                throw new UnknownException('Failed to find updated Subscription');
+            }
+
+            $newPlan = $this->plans->find($updated->getPlan()->getId());
+
+            if (null !== $newPlan) {
+                $updated->setPlan($newPlan);
+            }
+
+            return $subscription->merge($updated);
+        } catch (Exception $e) {
+            throw new SubscriptionNotUpdatedException($e->getMessage());
+        }
+    }
+
+    /**
+     * @param Successful|Error $result
+     */
+    private function isBillingFrequencyError($result): bool
+    {
+        if ($result->success || !$result instanceof Error) {
+            return false;
+        }
+
+        return !empty(array_filter(
+            $result->errors->deepAll(),
+            fn ($error) => Codes::SUBSCRIPTION_PLAN_BILLING_FREQUENCY_CANNOT_BE_UPDATED === $error->code
+        ));
+    }
+}

--- a/src/Processor/Braintree/Subscription/Update/UpdateStrategy.php
+++ b/src/Processor/Braintree/Subscription/Update/UpdateStrategy.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Subscription\Update;
+
+use TeamGantt\Dues\Model\Subscription;
+
+interface UpdateStrategy
+{
+    public function update(Subscription $subscription): ?Subscription;
+}

--- a/src/Processor/Braintree/Subscription/Update/UpdateStrategyFactory.php
+++ b/src/Processor/Braintree/Subscription/Update/UpdateStrategyFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Subscription\Update;
+
+use Braintree\Gateway;
+use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Model\Subscription\Status;
+use TeamGantt\Dues\Processor\Braintree\Mapper\SubscriptionMapper;
+use TeamGantt\Dues\Processor\Braintree\Repository\PlanRepository;
+use TeamGantt\Dues\Processor\Braintree\Repository\SubscriptionRepository;
+
+class UpdateStrategyFactory
+{
+    private Gateway $braintree;
+
+    private SubscriptionMapper $mapper;
+
+    private SubscriptionRepository $subscriptions;
+
+    private PlanRepository $plans;
+
+    public function __construct(
+        Gateway $braintree,
+        SubscriptionMapper $mapper,
+        SubscriptionRepository $subscriptions,
+        PlanRepository $plans
+    ) {
+        $this->braintree = $braintree;
+        $this->mapper = $mapper;
+        $this->subscriptions = $subscriptions;
+        $this->plans = $plans;
+    }
+
+    public function createStrategy(Subscription $subscription): UpdateStrategy
+    {
+        $braintree = $this->braintree;
+        $mapper = $this->mapper;
+        $subscriptions = $this->subscriptions;
+        $plans = $this->plans;
+
+        if ($subscription->is(Status::canceled())) {
+            return new CancelStrategy($braintree, $mapper, $subscriptions, $plans);
+        }
+
+        $changeBillingCycle = new ChangeBillingCycleStrategy($braintree, $mapper, $subscriptions, $plans);
+
+        return new DefaultUpdateStrategy($braintree, $mapper, $subscriptions, $plans, $changeBillingCycle);
+    }
+}

--- a/src/Processor/ProcessesSubscriptions.php
+++ b/src/Processor/ProcessesSubscriptions.php
@@ -2,12 +2,14 @@
 
 namespace TeamGantt\Dues\Processor;
 
+use DateTime;
 use TeamGantt\Dues\Contracts\SubscriptionGateway;
 use TeamGantt\Dues\Model\Customer;
 use TeamGantt\Dues\Model\PaymentMethod;
 use TeamGantt\Dues\Model\Plan;
 use TeamGantt\Dues\Model\Subscription;
 use TeamGantt\Dues\Model\Subscription\Status;
+use TeamGantt\Dues\Model\Transaction;
 
 /**
  * This trait exists to provide simple delegation to a SubscriptionGateway.
@@ -79,6 +81,14 @@ trait ProcessesSubscriptions
     public function findSubscriptionById(string $subscriptionId): ?Subscription
     {
         return $this->gateway->findSubscriptionById($subscriptionId);
+    }
+
+    /**
+     * @return Transaction[]
+     */
+    public function findTransactionsByCustomerId(string $customerId, ?DateTime $start = null, ?DateTime $end = null): array
+    {
+        return $this->gateway->findTransactionsByCustomerId($customerId, $start, $end);
     }
 
     public function listAddOns(): array

--- a/tests/Feature/Subscription.php
+++ b/tests/Feature/Subscription.php
@@ -317,6 +317,7 @@ trait Subscription
         $this->assertFalse($subscription->getCustomer()->isNew());
         $this->assertFalse($subscription->isNew());
         $this->assertEquals(Status::active(), $subscription->getStatus());
+        $this->assertNotEmpty($subscription->getTransactions());
     }
 
     /**

--- a/tests/Feature/Subscription.php
+++ b/tests/Feature/Subscription.php
@@ -137,9 +137,12 @@ trait Subscription
 
         $this->assertEquals('test-plan-c-monthly', $updated->getPlan()->getId());
         $this->assertEquals($plan->getPrice()->getAmount(), $updated->getPrice()->getAmount());
-        $previous = $subscription->toArray();
-        $next = $updated->toArray();
-        $this->assertEquals(Arr::dissoc($previous, ['id', 'plan', 'price']), Arr::dissoc($next, ['id', 'plan', 'price']));
+        $this->assertGreaterThan(0, count($updated->getDiscounts()));
+        $balance = $updated->getBalance()->getAmount();
+        $price = $updated->getPrice()->getAmount();
+        $addOnPrice = $updated->getAddOns()[0]->getPrice()->getAmount();
+        $rollover = $subscription->getBalance()->getAmount();
+        $this->assertEquals($rollover + $price + $addOnPrice, $balance);
     }
 
     /**

--- a/tests/Feature/Subscription.php
+++ b/tests/Feature/Subscription.php
@@ -138,6 +138,7 @@ trait Subscription
         $this->assertEquals('test-plan-c-monthly', $updated->getPlan()->getId());
         $this->assertEquals($plan->getPrice()->getAmount(), $updated->getPrice()->getAmount());
         $this->assertGreaterThan(0, count($updated->getDiscounts()));
+        $this->assertTrue($updated->getStatus() !== Status::canceled());
         $balance = $updated->getBalance()->getAmount();
         $price = $updated->getPrice()->getAmount();
         $addOnPrice = $updated->getAddOns()[0]->getPrice()->getAmount();

--- a/tests/Feature/Transaction.php
+++ b/tests/Feature/Transaction.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TeamGantt\Dues\Tests\Feature;
+
+use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Tests\ProvidesTestData;
+
+trait Transaction
+{
+    use ProvidesTestData;
+
+    /**
+     * @group integration
+     * @dataProvider subscriptionProvider
+     *
+     * @return void
+     */
+    public function testFindTransactionsByCustomerId(callable $subscriptionFactory)
+    {
+        $subscription = $subscriptionFactory($this->dues, null, fn (Subscription $s) => $s->beginImmediately());
+        $customer = $subscription->getCustomer();
+
+        $transactions = $this->dues->findTransactionsByCustomerId($customer->getId());
+        $sample = $transactions[0];
+
+        $this->assertTrue(!$sample->isNew());
+    }
+}

--- a/tests/Processor/ProcessorTestCase.php
+++ b/tests/Processor/ProcessorTestCase.php
@@ -18,6 +18,7 @@ abstract class ProcessorTestCase extends TestCase
     use Feature\PaymentMethod;
     use Feature\Plan;
     use Feature\Subscription;
+    use Feature\Transaction;
 
     protected ?Dues $dues = null;
 


### PR DESCRIPTION
@johncorrelli This includes the stuff we paired through and some refactors.

I really wanted to extract some classes for subscription updating before it got away from us. Some more classes, but it allows us to focus on each update scenario independently. Hopefully a win!

The last commit adds transaction support. The transaction search does not support searching by subscription id, but I made it so subscriptions are returned with an array of Transaction objects on them.

If we want a method like `findTransactionsBySubscriptionId` - then it will just call `findSubscriptionById` and return the found subscription's transactions. Wasn't sure if we needed that, so let me know what you are thinking 🙇 