### PR TITLE
fix(types): cast customer attributes to string

### DIFF
--- a/src/Processor/Braintree/Mapper/CustomerMapper.php
+++ b/src/Processor/Braintree/Mapper/CustomerMapper.php
@@ -38,9 +38,9 @@ class CustomerMapper
 
         $customer = $builder
             ->withId($result->id)
-            ->withEmailAddress($result->email)
-            ->withFirstName($result->firstName)
-            ->withLastName($result->lastName)
+            ->withEmailAddress((string) $result->email)
+            ->withFirstName((string) $result->firstName)
+            ->withLastName((string) $result->lastName)
             ->build();
 
         foreach ($result->paymentMethods as $paymentMethod) {

--- a/src/Processor/Braintree/Mapper/TransactionMapper.php
+++ b/src/Processor/Braintree/Mapper/TransactionMapper.php
@@ -47,9 +47,9 @@ class TransactionMapper
         $customer = new Customer($details->id);
 
         return $customer
-            ->setEmailAddress($details->email)
-            ->setFirstName($details->firstName)
-            ->setLastName($details->lastName);
+            ->setEmailAddress((string) $details->email)
+            ->setFirstName((string) $details->firstName)
+            ->setLastName((string) $details->lastName);
     }
 
     private function getType(BraintreeTransaction $result): Type


### PR DESCRIPTION
Braintree is converting the name of `""` (empty string) to `null` which breaks our types.