### PR TITLE
chore: add initial events implementation

### DIFF
--- a/src/Contracts/EventListener.php
+++ b/src/Contracts/EventListener.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace TeamGantt\Dues\Contracts;
+
+use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\Subscription;
+
+interface EventListener
+{
+    public function onAfterCreateCustomer(Customer $customer): void;
+
+    public function onAfterUpdateCustomer(Customer $customer): void;
+
+    public function onBeforeCreateCustomer(Customer $customer): void;
+
+    public function onBeforeUpdateCustomer(Customer $customer): void;
+
+    public function onAfterCreateSubscription(Subscription $subscription): void;
+
+    public function onAfterUpdateSubscription(Subscription $subscription): void;
+
+    public function onBeforeCreateSubscription(Subscription $subscription): void;
+
+    public function onBeforeUpdateSubscription(Subscription $subscription): void;
+}

--- a/src/Contracts/EventListenerContainer.php
+++ b/src/Contracts/EventListenerContainer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace TeamGantt\Dues\Contracts;
+
+interface EventListenerContainer
+{
+    public function addListener(EventListener $listener): void;
+
+    public function removeListener(EventListener $listener): void;
+}

--- a/src/Dues.php
+++ b/src/Dues.php
@@ -2,7 +2,10 @@
 
 namespace TeamGantt\Dues;
 
+use TeamGantt\Dues\Contracts\EventListener;
+use TeamGantt\Dues\Contracts\EventListenerContainer;
 use TeamGantt\Dues\Contracts\SubscriptionGateway;
+use TeamGantt\Dues\Event\Dispatcher;
 use TeamGantt\Dues\Exception\CustomerNotUpdatedException;
 use TeamGantt\Dues\Exception\SubscriptionNotCreatedException;
 use TeamGantt\Dues\Model\Customer;
@@ -14,7 +17,7 @@ use TeamGantt\Dues\Processor\ProcessesSubscriptions;
 /**
  * Dues does subscriptions dawgz.
  */
-class Dues implements SubscriptionGateway
+class Dues implements SubscriptionGateway, EventListenerContainer
 {
     /*
      * Dues processes subscriptions. Includes the ProcessesSubscriptions trait
@@ -27,9 +30,22 @@ class Dues implements SubscriptionGateway
 
     private SubscriptionGateway $gateway;
 
+    private Dispatcher $events;
+
     public function __construct(SubscriptionGateway $gateway)
     {
         $this->gateway = $gateway;
+        $this->events = new Dispatcher();
+    }
+
+    public function addListener(EventListener $listener): void
+    {
+        $this->events->addListener($listener);
+    }
+
+    public function removeListener(EventListener $listener): void
+    {
+        $this->events->removeListener($listener);
     }
 
     /**

--- a/src/Event/BaseEventListener.php
+++ b/src/Event/BaseEventListener.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace TeamGantt\Dues\Event;
+
+use TeamGantt\Dues\Contracts\EventListener;
+use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\Subscription;
+
+class BaseEventListener implements EventListener
+{
+    public function onBeforeCreateCustomer(Customer $customer): void
+    {
+    }
+
+    public function onAfterCreateCustomer(Customer $customer): void
+    {
+    }
+
+    public function onBeforeUpdateCustomer(Customer $customer): void
+    {
+    }
+
+    public function onAfterUpdateCustomer(Customer $customer): void
+    {
+    }
+
+    public function onBeforeCreateSubscription(Subscription $subscription): void
+    {
+    }
+
+    public function onAfterCreateSubscription(Subscription $subscription): void
+    {
+    }
+
+    public function onBeforeUpdateSubscription(Subscription $subscription): void
+    {
+    }
+
+    public function onAfterUpdateSubscription(Subscription $subscription): void
+    {
+    }
+}

--- a/src/Event/Dispatcher.php
+++ b/src/Event/Dispatcher.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace TeamGantt\Dues\Event;
+
+use SplObjectStorage;
+use TeamGantt\Dues\Contracts\EventListener;
+use TeamGantt\Dues\Contracts\EventListenerContainer;
+use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\Subscription;
+
+class Dispatcher implements EventListenerContainer
+{
+    /**
+     * @var SplObjectStorage<EventListener>
+     */
+    protected SplObjectStorage $listeners;
+
+    public function __construct()
+    {
+        /* @phpstan-ignore-next-line */
+        $this->listeners = new SplObjectStorage();
+    }
+
+    public function addListener(EventListener $listener): void
+    {
+        $this->listeners->attach($listener);
+    }
+
+    public function removeListener(EventListener $listener): void
+    {
+        $this->listeners->detach($listener);
+    }
+
+    /**
+     * @param Subscription|Customer $model
+     */
+    public function dispatch(EventType $type, $model): void
+    {
+        foreach ($this->listeners as $listener) {
+            if ($model instanceof Customer) {
+                if ($type->equals(EventType::afterCreateCustomer())) {
+                    $listener->onAfterCreateCustomer($model);
+                } elseif ($type->equals(EventType::afterUpdateCustomer())) {
+                    $listener->onAfterUpdateCustomer($model);
+                } elseif ($type->equals(EventType::beforeCreateCustomer())) {
+                    $listener->onBeforeCreateCustomer($model);
+                } elseif ($type->equals(EventType::beforeUpdateCustomer())) {
+                    $listener->onBeforeUpdateCustomer($model);
+                }
+            }
+
+            if ($model instanceof Subscription) {
+                if ($type->equals(EventType::afterCreateSubscription())) {
+                    $listener->onAfterCreateSubscription($model);
+                } elseif ($type->equals(EventType::afterUpdateSubscription())) {
+                    $listener->onAfterUpdateSubscription($model);
+                } elseif ($type->equals(EventType::beforeCreateSubscription())) {
+                    $listener->onBeforeCreateSubscription($model);
+                } elseif ($type->equals(EventType::beforeUpdateSubscription())) {
+                    $listener->onBeforeUpdateSubscription($model);
+                }
+            }
+        }
+    }
+}

--- a/src/Event/EventType.php
+++ b/src/Event/EventType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TeamGantt\Dues\Event;
+
+use Spatie\Enum\Enum;
+
+/**
+ * @method static self beforeCreateCustomer()
+ * @method static self afterCreateCustomer()
+ * @method static self beforeUpdateCustomer()
+ * @method static self afterUpdateCustomer()
+ * @method static self beforeCreateSubscription()
+ * @method static self afterCreateSubscription()
+ * @method static self beforeUpdateSubscription()
+ * @method static self afterUpdateSubscription()
+ */
+class EventType extends Enum
+{
+}

--- a/tests/Event/DispatcherTest.php
+++ b/tests/Event/DispatcherTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace TeamGantt\Dues\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use TeamGantt\Dues\Contracts\EventListener;
+use TeamGantt\Dues\Event\Dispatcher;
+use TeamGantt\Dues\Event\EventType;
+use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\Subscription;
+
+final class DispatcherTest extends TestCase
+{
+    protected $dispatcher;
+
+    protected function setUp(): void
+    {
+        $this->dispatcher = new Dispatcher();
+    }
+
+    public function testDispatchAfterCreateCustomer()
+    {
+        $listener = $this->createMock(EventListener::class);
+        $customer = new Customer('id');
+        $this->dispatcher->addListener($listener);
+
+        $listener
+            ->expects($this->once())
+            ->method('onAfterCreateCustomer')
+            ->with($customer);
+
+        $this->dispatcher->dispatch(EventType::afterCreateCustomer(), $customer);
+    }
+
+    public function testDispatchAfterUpdateCustomer()
+    {
+        $listener = $this->createMock(EventListener::class);
+        $customer = new Customer('id');
+        $this->dispatcher->addListener($listener);
+
+        $listener
+            ->expects($this->once())
+            ->method('onAfterUpdateCustomer')
+            ->with($customer);
+
+        $this->dispatcher->dispatch(EventType::afterUpdateCustomer(), $customer);
+    }
+
+    public function testDispatchBeforeCreateCustomer()
+    {
+        $listener = $this->createMock(EventListener::class);
+        $customer = new Customer();
+        $this->dispatcher->addListener($listener);
+
+        $listener
+            ->expects($this->once())
+            ->method('onBeforeCreateCustomer')
+            ->with($customer);
+
+        $this->dispatcher->dispatch(EventType::beforeCreateCustomer(), $customer);
+    }
+
+    public function testDispatchBeforeUpdateCustomer()
+    {
+        $listener = $this->createMock(EventListener::class);
+        $customer = new Customer('id');
+        $this->dispatcher->addListener($listener);
+
+        $listener
+            ->expects($this->once())
+            ->method('onBeforeUpdateCustomer')
+            ->with($customer);
+
+        $this->dispatcher->dispatch(EventType::beforeUpdateCustomer(), $customer);
+    }
+
+    public function testDispatchAfterCreateSubscription()
+    {
+        $listener = $this->createMock(EventListener::class);
+        $subscription = new Subscription('id');
+        $this->dispatcher->addListener($listener);
+
+        $listener
+            ->expects($this->once())
+            ->method('onAfterCreateSubscription')
+            ->with($subscription);
+
+        $this->dispatcher->dispatch(EventType::afterCreateSubscription(), $subscription);
+    }
+
+    public function testDispatchAfterUpdateSubscription()
+    {
+        $listener = $this->createMock(EventListener::class);
+        $subscription = new Subscription('id');
+        $this->dispatcher->addListener($listener);
+
+        $listener
+            ->expects($this->once())
+            ->method('onAfterUpdateSubscription')
+            ->with($subscription);
+
+        $this->dispatcher->dispatch(EventType::afterUpdateSubscription(), $subscription);
+    }
+
+    public function testDispatchBeforeCreateSubscription()
+    {
+        $listener = $this->createMock(EventListener::class);
+        $subscription = new Subscription();
+        $this->dispatcher->addListener($listener);
+
+        $listener
+            ->expects($this->once())
+            ->method('onBeforeCreateSubscription')
+            ->with($subscription);
+
+        $this->dispatcher->dispatch(EventType::beforeCreateSubscription(), $subscription);
+    }
+
+    public function testDispatchBeforeUpdateSubscription()
+    {
+        $listener = $this->createMock(EventListener::class);
+        $subscription = new Subscription('id');
+        $this->dispatcher->addListener($listener);
+
+        $listener
+            ->expects($this->once())
+            ->method('onBeforeUpdateSubscription')
+            ->with($subscription);
+
+        $this->dispatcher->dispatch(EventType::beforeUpdateSubscription(), $subscription);
+    }
+}


### PR DESCRIPTION
This is the initial event system for dues. Fairly standard run of the mill observer pattern.

An example listener may do something with taxes:

```php
class TaxListener extends BaseEventListener
{
    public function onBeforeCreateSubscription(Subscription $subscription)
    {
        $tax = $this->calculateTax();
        $subscription->addOn(new AddOn('tax-fun', 1, new Price($tax)));
    }
}

// wherever Dues is instantiated:
$dues->addListener(new TaxListener());
```

A listener just has to implement the `EventListener` interface. A `BaseEventListener` class is provided to provide a stub implementation for all events. 