### PR TITLE
feat: customer payment tokens

### DIFF
--- a/src/Contracts/SubscriptionGateway.php
+++ b/src/Contracts/SubscriptionGateway.php
@@ -4,6 +4,7 @@ namespace TeamGantt\Dues\Contracts;
 
 use DateTime;
 use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\Customer\CustomerSession;
 use TeamGantt\Dues\Model\Modifier\AddOn;
 use TeamGantt\Dues\Model\Modifier\Discount;
 use TeamGantt\Dues\Model\PaymentMethod;
@@ -47,6 +48,8 @@ interface SubscriptionGateway
     public function findSubscriptionById(string $subscriptionId): ?Subscription;
 
     public function findTransactionById(string $transactionId): ?Transaction;
+
+    public function createCustomerSession(string $customerId): CustomerSession;
 
     /**
      * @return Transaction[]

--- a/src/Model/Customer/CustomerSession.php
+++ b/src/Model/Customer/CustomerSession.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace TeamGantt\Dues\Model\Customer;
+
+use TeamGantt\Dues\Model\Entity;
+
+class CustomerSession extends Entity
+{
+}

--- a/src/Processor/Braintree.php
+++ b/src/Processor/Braintree.php
@@ -6,6 +6,7 @@ use Braintree\Gateway as BraintreeGateway;
 use DateTime;
 use TeamGantt\Dues\Contracts\SubscriptionGateway;
 use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\Customer\CustomerSession;
 use TeamGantt\Dues\Model\Modifier\AddOn;
 use TeamGantt\Dues\Model\Modifier\Discount;
 use TeamGantt\Dues\Model\PaymentMethod;
@@ -109,6 +110,11 @@ class Braintree implements SubscriptionGateway
     public function findTransactionById(string $transactionId): ?Transaction
     {
         return $this->transactions->find($transactionId);
+    }
+
+    public function createCustomerSession(string $customerId): CustomerSession
+    {
+        return $this->customers->createCustomerSession($customerId);
     }
 
     /**

--- a/src/Processor/Braintree/Mapper/PaymentMethodMapper.php
+++ b/src/Processor/Braintree/Mapper/PaymentMethodMapper.php
@@ -26,6 +26,7 @@ class PaymentMethodMapper
         }
 
         $request = Arr::replaceKeys($paymentMethod->toArray(), ['nonce' => 'paymentMethodNonce']);
+        $request = Arr::assocIn($request, ['options'], ['verifyCard' => true, 'makeDefault' => $paymentMethod->isDefaultPaymentMethod()]);
 
         return Arr::updateIn($request, ['billingAddress'], function ($address) {
             if (empty($address)) {

--- a/src/Processor/Braintree/Repository/CustomerRepository.php
+++ b/src/Processor/Braintree/Repository/CustomerRepository.php
@@ -11,6 +11,7 @@ use TeamGantt\Dues\Exception\CustomerNotUpdatedException;
 use TeamGantt\Dues\Exception\InvariantException;
 use TeamGantt\Dues\Exception\UnknownException;
 use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\Customer\CustomerSession;
 use TeamGantt\Dues\Model\PaymentMethod;
 use TeamGantt\Dues\Processor\Braintree\Mapper\CustomerMapper;
 
@@ -141,5 +142,12 @@ class CustomerRepository
         } catch (Exception $e) {
             return null;
         }
+    }
+
+    public function createCustomerSession(string $customerId): CustomerSession
+    {
+        $id = $this->braintree->clientToken()->generate(['customerId' => $customerId]);
+
+        return new CustomerSession($id);
     }
 }

--- a/src/Processor/ProcessesSubscriptions.php
+++ b/src/Processor/ProcessesSubscriptions.php
@@ -7,6 +7,7 @@ use TeamGantt\Dues\Contracts\SubscriptionGateway;
 use TeamGantt\Dues\Event\Dispatcher;
 use TeamGantt\Dues\Event\EventType;
 use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\Customer\CustomerSession;
 use TeamGantt\Dues\Model\Modifier\AddOn;
 use TeamGantt\Dues\Model\Modifier\Discount;
 use TeamGantt\Dues\Model\PaymentMethod;
@@ -114,6 +115,11 @@ trait ProcessesSubscriptions
     public function findSubscriptionById(string $subscriptionId): ?Subscription
     {
         return $this->gateway->findSubscriptionById($subscriptionId);
+    }
+
+    public function createCustomerSession(string $customerId): CustomerSession
+    {
+        return $this->gateway->createCustomerSession($customerId);
     }
 
     public function findTransactionById(string $transactionId): ?Transaction

--- a/tests/Feature/PaymentMethod.php
+++ b/tests/Feature/PaymentMethod.php
@@ -78,4 +78,32 @@ trait PaymentMethod
         $paymentMethod = $this->dues->createPaymentMethod($paymentMethod);
         $this->assertInstanceOf(Token::class, $paymentMethod);
     }
+
+    /**
+     * @group integration
+     *
+     * @return void
+     *
+     * @throws ExpectationFailedException
+     * @throws InvalidArgumentException
+     * @throws Exception
+     */
+    public function testCreateCustomerSession()
+    {
+        $customer = (new CustomerBuilder())
+            ->withFirstName('Bill')
+            ->withLastName('Steffen')
+            ->withEmailAddress('bill.steffen@email.com')
+            ->build();
+
+        $customer = $this->dues->createCustomer($customer);
+        $paymentMethod = new Nonce('fake-valid-mastercard-nonce');
+        $paymentMethod->setCustomer($customer);
+
+        $paymentMethod = $this->dues->createPaymentMethod($paymentMethod);
+        $clientToken = $this->dues->createCustomerSession($customer->getId());
+
+        $this->assertTrue(is_string($clientToken->getId()));
+        $this->assertGreaterThan(2000, strlen($clientToken->getId()));
+    }
 }

--- a/tests/Feature/PaymentMethod.php
+++ b/tests/Feature/PaymentMethod.php
@@ -106,4 +106,44 @@ trait PaymentMethod
         $this->assertTrue(is_string($clientToken->getId()));
         $this->assertGreaterThan(2000, strlen($clientToken->getId()));
     }
+
+    /**
+     * @group integration
+     *
+     * @return void
+     *
+     * @throws ExpectationFailedException
+     * @throws InvalidArgumentException
+     * @throws Exception
+     */
+    public function testAddingAdditionalPaymentMethods()
+    {
+        $customer = (new CustomerBuilder())
+            ->withFirstName('Bill')
+            ->withLastName('Steffen')
+            ->withEmailAddress('bill.steffen@email.com')
+            ->build();
+
+        $customer = $this->dues->createCustomer($customer);
+
+        // the first payment method is always default
+        $initialMethod__default = new Nonce('fake-valid-mastercard-nonce');
+        $initialMethod__default->setCustomer($customer);
+        $first__default = $this->dues->createPaymentMethod($initialMethod__default);
+
+        // adding a second payment method to ensure it's not marked as default
+        $secondMethod__notDefault = new Nonce('fake-valid-visa-nonce');
+        $secondMethod__notDefault->setCustomer($customer);
+        $second__notDefault = $this->dues->createPaymentMethod($secondMethod__notDefault);
+
+        // adding a third and setting as default
+        $thirdMethod__default = new Nonce('fake-valid-discover-nonce');
+        $thirdMethod__default->setCustomer($customer);
+        $thirdMethod__default->setIsDefaultPaymentMethod(true);
+        $third__default = $this->dues->createPaymentMethod($thirdMethod__default);
+
+        $this->assertTrue($first__default->isDefaultPaymentMethod());
+        $this->assertFalse($second__notDefault->isDefaultPaymentMethod());
+        $this->assertTrue($third__default->isDefaultPaymentMethod());
+    }
 }


### PR DESCRIPTION
- [ ] generate a client token for a customer -> this is used for braintree's drop in UI used on a few places in our webclient
- [ ] fix: new payment methods with `setIsDefaultPaymentMethod(true)` should be marked as default