### PR TITLE
feat(subscription): add initial subscription search

### DIFF
--- a/src/Contracts/SubscriptionGateway.php
+++ b/src/Contracts/SubscriptionGateway.php
@@ -12,6 +12,7 @@ use TeamGantt\Dues\Model\Plan;
 use TeamGantt\Dues\Model\Subscription;
 use TeamGantt\Dues\Model\Subscription\Status;
 use TeamGantt\Dues\Model\Transaction;
+use TeamGantt\Dues\Processor\Braintree\Query\SubscriptionQuery;
 
 interface SubscriptionGateway
 {
@@ -81,4 +82,6 @@ interface SubscriptionGateway
     public function listPlans(): array;
 
     public function findPlanById(string $planId): ?Plan;
+
+    public function makeSubscriptionQuery(): SubscriptionQuery;
 }

--- a/src/Exception/InvalidSubscriptionSearchParamException.php
+++ b/src/Exception/InvalidSubscriptionSearchParamException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace TeamGantt\Dues\Exception;
+
+use RuntimeException;
+
+class InvalidSubscriptionSearchParamException extends RuntimeException
+{
+}

--- a/src/Processor/Braintree.php
+++ b/src/Processor/Braintree.php
@@ -22,6 +22,7 @@ use TeamGantt\Dues\Processor\Braintree\Mapper\PaymentMethodMapper;
 use TeamGantt\Dues\Processor\Braintree\Mapper\PlanMapper;
 use TeamGantt\Dues\Processor\Braintree\Mapper\SubscriptionMapper;
 use TeamGantt\Dues\Processor\Braintree\Mapper\TransactionMapper;
+use TeamGantt\Dues\Processor\Braintree\Query\SubscriptionQuery;
 use TeamGantt\Dues\Processor\Braintree\Repository\AddOnRepository;
 use TeamGantt\Dues\Processor\Braintree\Repository\CustomerRepository;
 use TeamGantt\Dues\Processor\Braintree\Repository\DiscountRepository;
@@ -32,6 +33,10 @@ use TeamGantt\Dues\Processor\Braintree\Repository\TransactionRepository;
 
 class Braintree implements SubscriptionGateway
 {
+    private BraintreeGateway $braintree;
+
+    private SubscriptionMapper $subscriptionMapper;
+
     private PaymentMethodRepository $paymentMethods;
 
     private CustomerRepository $customers;
@@ -62,6 +67,9 @@ class Braintree implements SubscriptionGateway
         $paymentMethodMapper = new PaymentMethodMapper();
         $customerMapper = new CustomerMapper($paymentMethodMapper);
         $planMapper = new PlanMapper($addOnMapper, $discountMapper);
+
+        $this->braintree = $braintree;
+        $this->subscriptionMapper = $subscriptionMapper;
 
         $this->paymentMethods = new PaymentMethodRepository($braintree, $paymentMethodMapper);
         $this->customers = new CustomerRepository($braintree, $customerMapper, $this->paymentMethods);
@@ -206,5 +214,10 @@ class Braintree implements SubscriptionGateway
     public function findPlanById(string $planId): ?Plan
     {
         return $this->plans->find($planId);
+    }
+
+    public function makeSubscriptionQuery(): SubscriptionQuery
+    {
+        return new SubscriptionQuery($this->braintree, $this->subscriptionMapper);
     }
 }

--- a/src/Processor/Braintree/Query/SubscriptionQuery.php
+++ b/src/Processor/Braintree/Query/SubscriptionQuery.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Query;
+
+use Braintree\Gateway;
+use Braintree\SubscriptionSearch;
+use TeamGantt\Dues\Exception\InvalidSubscriptionSearchParamException;
+use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Processor\Braintree\Mapper\SubscriptionMapper;
+
+class SubscriptionQuery
+{
+    private Gateway $gateway;
+
+    private SubscriptionMapper $mapper;
+
+    /**
+     * @var mixed[] Items appended must be supported search methods found in `\Braintree\SubscriptionSearch`
+     */
+    private array $searchParams = [];
+
+    public function __construct(Gateway $gateway, SubscriptionMapper $mapper)
+    {
+        $this->gateway = $gateway;
+        $this->mapper = $mapper;
+    }
+
+    public function whereDaysPastDue(string $comparison, int $days): self
+    {
+        if ('<=' === $comparison) {
+            $this->searchParams['daysPastDue'] = SubscriptionSearch::daysPastDue()->lessThanOrEqualTo($days);
+        } elseif ('=' === $comparison) {
+            $this->searchParams['daysPastDue'] = SubscriptionSearch::daysPastDue()->is($days);
+        } elseif ('>=' === $comparison) {
+            $this->searchParams['daysPastDue'] = SubscriptionSearch::daysPastDue()->greaterThanOrEqualTo($days);
+        } else {
+            throw new InvalidSubscriptionSearchParamException('Comparisons can only be "<=", "=", or ">="');
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Subscription[]
+     */
+    public function fetch(): array
+    {
+        $subscriptions = [];
+        $collection = $this->gateway->subscription()->search(array_values($this->searchParams));
+
+        foreach ($collection as $subscription) {
+            $subscriptions[] = $this->mapper->fromResult($subscription);
+        }
+
+        return $subscriptions;
+    }
+}

--- a/src/Processor/ProcessesSubscriptions.php
+++ b/src/Processor/ProcessesSubscriptions.php
@@ -15,6 +15,7 @@ use TeamGantt\Dues\Model\Plan;
 use TeamGantt\Dues\Model\Subscription;
 use TeamGantt\Dues\Model\Subscription\Status;
 use TeamGantt\Dues\Model\Transaction;
+use TeamGantt\Dues\Processor\Braintree\Query\SubscriptionQuery;
 
 /**
  * This trait exists to provide simple delegation to a SubscriptionGateway.
@@ -171,5 +172,10 @@ trait ProcessesSubscriptions
     public function findPlanById(string $planId): ?Plan
     {
         return $this->gateway->findPlanById($planId);
+    }
+
+    public function makeSubscriptionQuery(): SubscriptionQuery
+    {
+        return $this->gateway->makeSubscriptionQuery();
     }
 }

--- a/tests/Feature/Subscription.php
+++ b/tests/Feature/Subscription.php
@@ -737,4 +737,24 @@ trait Subscription
         $this->assertNotNull($discounts[0]->getPrice());
         $this->assertNotEmpty($discounts[0]->getId());
     }
+
+    public function testSubscriptionSearchWithDaysPastDue()
+    {
+        $query = $this->dues->makeSubscriptionQuery();
+        $overdue = $query->whereDaysPastDue('>=', 1)->fetch();
+
+        // this assumes that you have at least one past due subscription in your processor.
+        // for the case of braintree, you can create a past due subscription by using an
+        // invalid payment method `fake-invalid-nonce` and setting a start date in the future.
+        // The subscription will fail to start, and immediately go into an past due status.
+        $this->assertGreaterThan(0, $overdue);
+
+        // should be an unreachable case, but we're verifying that the query works
+        $overdue = $query->whereDaysPastDue('<=', -1)->fetch();
+        $this->assertEquals(0, count($overdue));
+
+        // should be an unreachable case, but we're verifying that the query works
+        $overdue = $query->whereDaysPastDue('=', -2)->fetch();
+        $this->assertEquals(0, count($overdue));
+    }
 }


### PR DESCRIPTION
- I just added support for the days past due and the three ways you can search on that. They do not support `<` or `>`, both have `=` with them.
- Exceptions are thrown if an invalid comparison is used.
- Since the search requires data that we can't prime in a test... I had to add a long description... see what you think.