### PR TITLE
feat(subscriptions): update payment method for past due subscriptions

### DIFF
--- a/src/Processor/Braintree/Subscription/Update/PastDueUpdateStrategy.php
+++ b/src/Processor/Braintree/Subscription/Update/PastDueUpdateStrategy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Subscription\Update;
+
+use Braintree\Result\Error;
+use Braintree\Result\Successful;
+use Exception;
+use TeamGantt\Dues\Exception\SubscriptionNotUpdatedException;
+use TeamGantt\Dues\Model\PaymentMethod\Token;
+use TeamGantt\Dues\Model\Subscription;
+
+class PastDueUpdateStrategy extends DefaultUpdateStrategy
+{
+    public function update(Subscription $subscription): ?Subscription
+    {
+        try {
+            // handle delinquent subscription.
+            $this->setNewPaymentMethod($subscription);
+            $this->retrySubscription($subscription);
+
+            // update the no longer delinquent subscription per changes provided.
+            return parent::update($subscription);
+        } catch (Exception $e) {
+            throw new SubscriptionNotUpdatedException($e->getMessage());
+        }
+    }
+
+    /**
+     * Sets only the new payment method for the existing subscription that is past due.
+     */
+    private function setNewPaymentMethod(Subscription $subscription): Successful
+    {
+        $paymentMethod = $subscription->getPaymentMethod();
+
+        if (!($paymentMethod instanceof Token)) {
+            throw new SubscriptionNotUpdatedException('A valid payment token must be supplied.');
+        }
+
+        $paymentTokenRequest = ['paymentMethodToken' => $paymentMethod->getValue()];
+
+        $updatePaymentMethod = $this
+            ->braintree
+            ->subscription()
+            ->update($subscription->getId(), $paymentTokenRequest);
+
+        if ($updatePaymentMethod instanceof Error) {
+            throw new SubscriptionNotUpdatedException('Unable to update the payment method on the current subscription.');
+        }
+
+        return $updatePaymentMethod;
+    }
+
+    /**
+     * After a new payment method has been assigned attempt to bring the subscription to current.
+     */
+    private function retrySubscription(Subscription $subscription): Successful
+    {
+        $retrySubscription = $this->braintree->subscription()->retryCharge($subscription->getId());
+
+        if ($retrySubscription instanceof Error) {
+            throw new SubscriptionNotUpdatedException('Unable to resolve delinquent subscription before upgrading.');
+        }
+
+        return $retrySubscription;
+    }
+}

--- a/src/Processor/Braintree/Subscription/Update/UpdateStrategyFactory.php
+++ b/src/Processor/Braintree/Subscription/Update/UpdateStrategyFactory.php
@@ -44,6 +44,10 @@ class UpdateStrategyFactory
 
         $changeBillingCycle = new ChangeBillingCycleStrategy($braintree, $mapper, $subscriptions, $plans);
 
+        if ($subscription->is(Status::pastDue())) {
+            return new PastDueUpdateStrategy($braintree, $mapper, $subscriptions, $plans, $changeBillingCycle);
+        }
+
         return new DefaultUpdateStrategy($braintree, $mapper, $subscriptions, $plans, $changeBillingCycle);
     }
 }


### PR DESCRIPTION
## PROOF!
![Screenshot_20210107_155200](https://user-images.githubusercontent.com/18272064/103943608-5d2cd080-5100-11eb-9730-a04bf1c66013.png)

## WHAT'S UP
- when a subscription is past due, you can't change things that may affect the price... and that could be one of many things.

## WHAT'S HAPPENING
- Before updating the subscription, if the subscription is past due and we're updating the payment method, we:
    - update the payment method
    - retry the subscription (to bring it up-to-date)
    - return any errors along the way
    - if successful, carry on

## UM, WHAT ABOUT TESTS?
- as you can see, the existing all pass above
- the problem is, we can't programmatically create past due subscriptions... you have to create a pending subscription that will fail when it gets to that date... you're looking at a min 24 hour window to create the scenario.
- I can prove it with our use case if you would like to see that