### PR TITLE
feat(subscriptions): add status history

### DIFF
--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -13,6 +13,7 @@ use TeamGantt\Dues\Model\Subscription\Modifier\Operation;
 use TeamGantt\Dues\Model\Subscription\Modifier\OperationType;
 use TeamGantt\Dues\Model\Subscription\Modifiers;
 use TeamGantt\Dues\Model\Subscription\Status;
+use TeamGantt\Dues\Model\Subscription\StatusHistory;
 
 class Subscription extends Entity implements Arrayable
 {
@@ -39,6 +40,11 @@ class Subscription extends Entity implements Arrayable
     protected Modifiers $discounts;
 
     /**
+     * @var StatusHistory[]
+     */
+    protected array $statusHistory = [];
+
+    /**
      * @var Transaction[]
      */
     protected array $transactions = [];
@@ -63,6 +69,7 @@ class Subscription extends Entity implements Arrayable
             'startDate' => $this->getStartDate(),
             'price' => empty($price) ? null : $price->toArray(),
             'status' => $this->getStatus(),
+            'statusHistory' => $this->getStatusHistory(),
             'daysPastDue' => $this->getDaysPastDue(),
             'customer' => $this->getCustomer()->toArray(),
             'payment' => empty($payment) ? null : $payment->toArray(),
@@ -87,6 +94,7 @@ class Subscription extends Entity implements Arrayable
         }
 
         $this->setStatus($other->getStatus());
+        $this->setStatusHistory($other->getStatusHistory());
 
         $this->setDaysPastDue($other->getDaysPastDue());
 
@@ -306,11 +314,29 @@ class Subscription extends Entity implements Arrayable
     }
 
     /**
+     * @return StatusHistory[]
+     */
+    public function getStatusHistory(): array
+    {
+        return $this->statusHistory;
+    }
+
+    /**
      * @return Subscription
      */
     public function setStatus(Status $status): self
     {
         $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * @param StatusHistory[] $statusHistory
+     */
+    public function setStatusHistory(array $statusHistory): self
+    {
+        $this->statusHistory = $statusHistory;
 
         return $this;
     }

--- a/src/Model/Subscription/StatusHistory.php
+++ b/src/Model/Subscription/StatusHistory.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace TeamGantt\Dues\Model\Subscription;
+
+use DateTime;
+use TeamGantt\Dues\Contracts\Arrayable;
+use TeamGantt\Dues\Model\Money;
+
+class StatusHistory implements Arrayable
+{
+    public DateTime $timestamp;
+
+    public Status $status;
+
+    public Money $balance;
+
+    public Money $price;
+
+    public string $planId;
+
+    public function __construct(DateTime $timestamp)
+    {
+        $this->timestamp = $timestamp;
+    }
+
+    public function setStatus(Status $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function setBalance(Money $balance): self
+    {
+        $this->balance = $balance;
+
+        return $this;
+    }
+
+    public function setPrice(Money $price): self
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    public function setPlanId(string $planId): self
+    {
+        $this->planId = $planId;
+
+        return $this;
+    }
+
+    public function getStatus(): Status
+    {
+        return $this->status;
+    }
+
+    public function getBalance(): Money
+    {
+        return $this->balance;
+    }
+
+    public function getPrice(): Money
+    {
+        return $this->price;
+    }
+
+    public function getPlanId(): string
+    {
+        return $this->planId;
+    }
+
+    public function getTimestamp(): DateTime
+    {
+        return $this->timestamp;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'timestamp' => $this->timestamp,
+            'status' => isset($this->status) ? $this->status : null,
+            'balance' => isset($this->balance) ? $this->balance->getAmount() : null,
+            'price' => isset($this->price) ? $this->price->getAmount() : null,
+            'planId' => isset($this->planId) ? $this->planId : null,
+        ]);
+    }
+}

--- a/src/Model/Subscription/SubscriptionBuilder.php
+++ b/src/Model/Subscription/SubscriptionBuilder.php
@@ -125,6 +125,16 @@ class SubscriptionBuilder extends Builder
     }
 
     /**
+     * @param StatusHistory[] $statusHistory
+     *
+     * @return SubscriptionBuilder
+     */
+    public function withStatusHistory(array $statusHistory): self
+    {
+        return $this->with('statusHistory', $statusHistory);
+    }
+
+    /**
      * @return SubscriptionBuilder
      */
     public function withDiscount(Discount $discount): self
@@ -169,6 +179,8 @@ class SubscriptionBuilder extends Builder
         }
 
         $subscription->setPlan($this->data['plan'] ?? new NullPlan());
+
+        $subscription->setStatusHistory($this->data['statusHistory'] ?? []);
 
         $this->reset();
 

--- a/src/Processor/Braintree.php
+++ b/src/Processor/Braintree.php
@@ -21,6 +21,7 @@ use TeamGantt\Dues\Processor\Braintree\Mapper\CustomerMapper;
 use TeamGantt\Dues\Processor\Braintree\Mapper\DiscountMapper;
 use TeamGantt\Dues\Processor\Braintree\Mapper\PaymentMethodMapper;
 use TeamGantt\Dues\Processor\Braintree\Mapper\PlanMapper;
+use TeamGantt\Dues\Processor\Braintree\Mapper\StatusHistoryMapper;
 use TeamGantt\Dues\Processor\Braintree\Mapper\SubscriptionMapper;
 use TeamGantt\Dues\Processor\Braintree\Mapper\TransactionMapper;
 use TeamGantt\Dues\Processor\Braintree\Query\SubscriptionQuery;
@@ -66,7 +67,8 @@ class Braintree implements SubscriptionGateway
         $addOnMapper = new AddOnMapper();
         $discountMapper = new DiscountMapper();
         $transactionMapper = new TransactionMapper($addOnMapper, $discountMapper);
-        $subscriptionMapper = new SubscriptionMapper($addOnMapper, $discountMapper, $transactionMapper);
+        $statusHistoryMapper = new StatusHistoryMapper();
+        $subscriptionMapper = new SubscriptionMapper($addOnMapper, $discountMapper, $transactionMapper, $statusHistoryMapper);
         $paymentMethodMapper = new PaymentMethodMapper();
         $customerMapper = new CustomerMapper($paymentMethodMapper);
         $planMapper = new PlanMapper($addOnMapper, $discountMapper);

--- a/src/Processor/Braintree/Mapper/StatusHistoryMapper.php
+++ b/src/Processor/Braintree/Mapper/StatusHistoryMapper.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Mapper;
+
+use Braintree\Subscription;
+use Braintree\Subscription\StatusDetails;
+use TeamGantt\Dues\Exception\UnknownStatusException;
+use TeamGantt\Dues\Model\Money;
+use TeamGantt\Dues\Model\Subscription\Status;
+use TeamGantt\Dues\Model\Subscription\StatusHistory;
+
+class StatusHistoryMapper
+{
+    /**
+     * @param StatusDetails[] $results
+     *
+     * @return StatusHistory[]
+     */
+    public function fromResults(array $results): array
+    {
+        return array_map(fn (StatusDetails $details) => $this->fromResult($details), $results);
+    }
+
+    public function fromResult(StatusDetails $details): StatusHistory
+    {
+        return (new StatusHistory($details->timestamp))
+            ->setStatus($this->getStatus($details))
+            ->setBalance(new Money((float) $details->balance))
+            ->setPrice(new Money((float) $details->price))
+            ->setPlanId($details->planId);
+    }
+
+    private function getStatus(StatusDetails $details): Status
+    {
+        $status = $details->status;
+
+        switch ($status) {
+            case Subscription::ACTIVE:
+                return Status::active();
+            case Subscription::CANCELED:
+                return Status::canceled();
+            case Subscription::EXPIRED:
+                return Status::expired();
+            case Subscription::PAST_DUE:
+                return Status::pastDue();
+            case Subscription::PENDING:
+                return Status::pending();
+            default:
+                throw new UnknownStatusException("Unknown status of $status received");
+        }
+    }
+}

--- a/src/Processor/Braintree/Mapper/SubscriptionMapper.php
+++ b/src/Processor/Braintree/Mapper/SubscriptionMapper.php
@@ -25,14 +25,18 @@ class SubscriptionMapper
 
     private ModifierMapper $modifierMapper;
 
+    private StatusHistoryMapper $statusHistoryMapper;
+
     public function __construct(
         AddOnMapper $addOnMapper,
         DiscountMapper $discountMapper,
-        TransactionMapper $transactionMapper
+        TransactionMapper $transactionMapper,
+        StatusHistoryMapper $statusHistoryMapper
     ) {
         $this->addOnMapper = $addOnMapper;
         $this->discountMapper = $discountMapper;
         $this->transactionMapper = $transactionMapper;
+        $this->statusHistoryMapper = $statusHistoryMapper;
         $this->modifierMapper = new ModifierMapper();
     }
 
@@ -98,6 +102,7 @@ class SubscriptionMapper
         $plan = new Plan($result->planId);
         $addOns = $this->addOnMapper->fromResults($result->addOns);
         $discounts = $this->discountMapper->fromResults($result->discounts);
+        $statusHistory = $this->statusHistoryMapper->fromResults($result->statusHistory);
 
         $subscription = $builder
             ->withId($result->id)
@@ -105,6 +110,7 @@ class SubscriptionMapper
             ->withBalance($balance)
             ->withPrice($price)
             ->withStatus($status)
+            ->withStatusHistory($statusHistory)
             ->withDaysPastDue($daysPastDue)
             ->withPaymentMethod($paymentMethod)
             ->withPlan($plan)

--- a/src/Processor/Braintree/Repository/SubscriptionRepository.php
+++ b/src/Processor/Braintree/Repository/SubscriptionRepository.php
@@ -65,7 +65,7 @@ class SubscriptionRepository
 
         $this->dispatch(EventType::beforeCreateSubscription(), $subscription);
         $request = $this->mapper->toRequest($subscription, $plan);
-        $request = Arr::dissoc($request, ['id', 'status']);
+        $request = Arr::dissoc($request, ['id', 'status', 'statusHistory']);
 
         $result = $this
             ->braintree

--- a/src/Processor/Braintree/Subscription/Update/BaseUpdateStrategy.php
+++ b/src/Processor/Braintree/Subscription/Update/BaseUpdateStrategy.php
@@ -40,7 +40,7 @@ abstract class BaseUpdateStrategy implements UpdateStrategy
     protected function doBraintreeUpdate(Subscription $subscription, ?Plan $newPlan = null)
     {
         $request = $this->mapper->toRequest($subscription, $newPlan);
-        $request = Arr::dissoc($request, ['firstBillingDate', 'status']);
+        $request = Arr::dissoc($request, ['firstBillingDate', 'status', 'statusHistory']);
         $request['options'] = ['prorateCharges' => true];
 
         return $this

--- a/tests/Feature/Subscription.php
+++ b/tests/Feature/Subscription.php
@@ -12,6 +12,7 @@ use TeamGantt\Dues\Exception\SubscriptionNotCreatedException;
 use TeamGantt\Dues\Exception\SubscriptionNotUpdatedException;
 use TeamGantt\Dues\Model\Modifier\AddOn;
 use TeamGantt\Dues\Model\Modifier\Discount;
+use TeamGantt\Dues\Model\Money;
 use TeamGantt\Dues\Model\Plan;
 use TeamGantt\Dues\Model\Price;
 use TeamGantt\Dues\Model\Subscription as ModelSubscription;
@@ -504,6 +505,12 @@ trait Subscription
         $this->assertEquals(Status::active(), $subscription->getStatus());
         $this->assertNotEmpty($subscription->getTransactions());
         $this->assertEquals(0, $subscription->getDaysPastDue());
+
+        $this->assertNotEmpty($subscription->getStatusHistory());
+        $this->assertEquals(Status::active(), $subscription->getStatusHistory()[0]->getStatus());
+        $this->assertEquals('test-plan-c-yearly', $subscription->getStatusHistory()[0]->getPlanId());
+        $this->assertEquals(new Money(0), $subscription->getStatusHistory()[0]->getBalance());
+        $this->assertEquals(new Money(150), $subscription->getStatusHistory()[0]->getPrice());
     }
 
     /**


### PR DESCRIPTION
# tests
![Screenshot_20210219_102532](https://user-images.githubusercontent.com/18272064/108524457-0852ad00-729d-11eb-900e-54a84f6bb325.png)
![Screenshot_20210219_103022](https://user-images.githubusercontent.com/18272064/108524855-7dbe7d80-729d-11eb-980f-99e0c7dfee5a.png)
![Screenshot_20210219_103005](https://user-images.githubusercontent.com/18272064/108524856-7dbe7d80-729d-11eb-8537-bcc69f20c9ff.png)


# why
- braintree doesn't give us for a transaction, what the cost of the subscription was at the time. This makes it difficult to give a proper invoice. By being able to return the subscription's [status history](https://developers.braintreepayments.com/reference/response/subscription/php#subscription-history) - we can pull the price from here and tie it back to the transaction.