### PR TITLE
feat: add more details to subscription

### DIFF
--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -39,6 +39,8 @@ class Subscription extends Entity implements Arrayable
 
     protected Modifiers $discounts;
 
+    protected ?Money $nextBillingPeriodAmount;
+
     /**
      * @var StatusHistory[]
      */
@@ -74,6 +76,7 @@ class Subscription extends Entity implements Arrayable
             'customer' => $this->getCustomer()->toArray(),
             'payment' => empty($payment) ? null : $payment->toArray(),
             'plan' => $this->plan->toArray(),
+            'nextBillingPeriodAmount' => $this->getNextBillingPeriodAmount(),
         ]);
     }
 
@@ -480,6 +483,22 @@ class Subscription extends Entity implements Arrayable
     public function addTransaction(Transaction $transaction): self
     {
         $this->transactions[] = $transaction;
+
+        return $this;
+    }
+
+    public function getNextBillingPeriodAmount(): ?Money
+    {
+        if (isset($this->nextBillingPeriodAmount)) {
+            return $this->nextBillingPeriodAmount;
+        }
+
+        return null;
+    }
+
+    public function setNextBillingPeriodAmount(Money $amount): self
+    {
+        $this->nextBillingPeriodAmount = $amount;
 
         return $this;
     }

--- a/src/Model/Subscription/SubscriptionBuilder.php
+++ b/src/Model/Subscription/SubscriptionBuilder.php
@@ -148,6 +148,14 @@ class SubscriptionBuilder extends Builder
         return $this;
     }
 
+    /**
+     * @return SubscriptionBuilder
+     */
+    public function withNextBillingPeriodAmount(Money $amount): self
+    {
+        return $this->with('nextBillingPeriodAmount', $amount);
+    }
+
     public function build(): Subscription
     {
         $subscription = (new Subscription($this->getId()))
@@ -166,6 +174,10 @@ class SubscriptionBuilder extends Builder
 
         if (isset($this->data['balance'])) {
             $subscription->setBalance($this->data['balance']);
+        }
+
+        if (isset($this->data['nextBillingPeriodAmount'])) {
+            $subscription->setNextBillingPeriodAmount($this->data['nextBillingPeriodAmount']);
         }
 
         $addOns = $this->data['addOns'] ?? [];

--- a/src/Processor/Braintree/Hydrator/SubscriptionHydrator.php
+++ b/src/Processor/Braintree/Hydrator/SubscriptionHydrator.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Hydrator;
+
+use TeamGantt\Dues\Model\Customer;
+use TeamGantt\Dues\Model\PaymentMethod\Token;
+use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Processor\Braintree\Repository\CustomerRepository;
+use TeamGantt\Dues\Processor\Braintree\Repository\PaymentMethodRepository;
+use TeamGantt\Dues\Processor\Braintree\Repository\PlanRepository;
+
+class SubscriptionHydrator
+{
+    protected CustomerRepository $customers;
+
+    protected PlanRepository $plans;
+
+    protected PaymentMethodRepository $paymentMethods;
+
+    public function __construct(
+        CustomerRepository $customers,
+        PlanRepository $plans,
+        PaymentMethodRepository $paymentMethods
+    ) {
+        $this->customers = $customers;
+        $this->plans = $plans;
+        $this->paymentMethods = $paymentMethods;
+    }
+
+    /**
+     * Hydrates subscriptions with Plans and Customer info.
+     *
+     * @param Subscription[] $subscriptions
+     */
+    public function hydrate(array $subscriptions): void
+    {
+        $this->hydratePlans($subscriptions);
+        $this->hydrateCustomer($subscriptions);
+    }
+
+    /**
+     * @param Subscription[] $subscriptions
+     */
+    private function hydrateCustomer(array $subscriptions): void
+    {
+        /**
+         * @var Customer[]
+         */
+        $cache = [];
+
+        foreach ($subscriptions as $subscription) {
+            $customer = null;
+            $paymentMethod = $subscription->getPaymentMethod();
+
+            if ($paymentMethod instanceof Token) {
+                $token = $paymentMethod->getValue();
+
+                $customer = isset($cache[$token])
+                    ? $cache[$token]
+                    : $this->getCustomerBySubscriptionPaymentToken($subscription, $paymentMethod);
+
+                $cache[$token] = $customer;
+            }
+
+            if (null === $customer) {
+                continue;
+            }
+
+            $subscription->setCustomer($customer);
+        }
+    }
+
+    /**
+     * Finds the customer based off of the customer id associated with the payment method and appends it back to the Subscription.
+     */
+    private function getCustomerBySubscriptionPaymentToken(Subscription $subscription, Token $paymentMethod): ?Customer
+    {
+        $customer = null;
+        $token = $paymentMethod->getValue();
+        $realPayment = $this->paymentMethods->findByToken($token);
+
+        if ($realPayment instanceof Token) {
+            $customer = $realPayment->getCustomer();
+
+            if ($customer instanceof Customer) {
+                $customerId = $customer->getId();
+                $realCustomer = $this->customers->find($customerId);
+
+                if ($realCustomer instanceof Customer) {
+                    $subscription->setCustomer($realCustomer);
+                    $customer = $realCustomer;
+                }
+            }
+        }
+
+        return $customer;
+    }
+
+    /**
+     * @param Subscription[] $subscriptions
+     */
+    private function hydratePlans(array $subscriptions): void
+    {
+        $cache = [];
+
+        foreach ($subscriptions as $subscription) {
+            $plan = $subscription->getPlan();
+
+            $hydrated = isset($cache[$plan->getId()]) ? $cache[$plan->getId()] : $this->plans->find($plan->getId());
+
+            if (null === $hydrated) {
+                continue;
+            }
+
+            if (!isset($cache[$hydrated->getId()])) {
+                $cache[$hydrated->getId()] = $hydrated;
+            }
+
+            $subscription->setPlan($hydrated);
+        }
+    }
+}

--- a/src/Processor/Braintree/Mapper/PaymentMethodMapper.php
+++ b/src/Processor/Braintree/Mapper/PaymentMethodMapper.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 use TeamGantt\Dues\Arr;
 use TeamGantt\Dues\Model\Address;
 use TeamGantt\Dues\Model\Address\State;
+use TeamGantt\Dues\Model\Customer;
 use TeamGantt\Dues\Model\PaymentMethod;
 use TeamGantt\Dues\Model\PaymentMethod\Nonce;
 use TeamGantt\Dues\Model\PaymentMethod\Token;
@@ -49,6 +50,7 @@ class PaymentMethodMapper
         $token = new Token($paymentMethod->token);
         $isDefault = $paymentMethod->isDefault();
         $token->setIsDefaultPaymentMethod($isDefault);
+        $token->setCustomer(new Customer($paymentMethod->customerId));
 
         $billingAddress = $paymentMethod->billingAddress;
         if ($billingAddress instanceof BraintreeAddress) {

--- a/src/Processor/Braintree/Mapper/SubscriptionMapper.php
+++ b/src/Processor/Braintree/Mapper/SubscriptionMapper.php
@@ -116,8 +116,13 @@ class SubscriptionMapper
             ->withStatusHistory($statusHistory)
             ->withDaysPastDue($daysPastDue)
             ->withPaymentMethod($paymentMethod)
-            ->withPlan($plan)
-            ->build();
+            ->withPlan($plan);
+
+        if (isset($result->nextBillingPeriodAmount)) {
+            $subscription->withNextBillingPeriodAmount(new Money(floatval($result->nextBillingPeriodAmount)));
+        }
+
+        $subscription = $subscription->build();
 
         foreach ($result->transactions as $transaction) {
             $subscription->addTransaction($this->transactionMapper->fromResult($transaction));

--- a/src/Processor/Braintree/Query/SubscriptionQuery.php
+++ b/src/Processor/Braintree/Query/SubscriptionQuery.php
@@ -3,10 +3,12 @@
 namespace TeamGantt\Dues\Processor\Braintree\Query;
 
 use Braintree\Gateway;
+use Braintree\Subscription as BraintreeSubscription;
 use Braintree\SubscriptionSearch;
 use DateTimeInterface;
 use TeamGantt\Dues\Exception\InvalidSubscriptionSearchParamException;
 use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Processor\Braintree\Hydrator\SubscriptionHydrator;
 use TeamGantt\Dues\Processor\Braintree\Mapper\SubscriptionMapper;
 
 class SubscriptionQuery
@@ -15,15 +17,18 @@ class SubscriptionQuery
 
     private SubscriptionMapper $mapper;
 
+    private SubscriptionHydrator $hydrator;
+
     /**
      * @var mixed[] Items appended must be supported search methods found in `\Braintree\SubscriptionSearch`
      */
     private array $searchParams = [];
 
-    public function __construct(Gateway $gateway, SubscriptionMapper $mapper)
+    public function __construct(Gateway $gateway, SubscriptionMapper $mapper, SubscriptionHydrator $hydrator)
     {
         $this->gateway = $gateway;
         $this->mapper = $mapper;
+        $this->hydrator = $hydrator;
     }
 
     public function whereDaysPastDue(string $comparison, int $days): self
@@ -66,6 +71,8 @@ class SubscriptionQuery
         foreach ($collection as $subscription) {
             $subscriptions[] = $this->mapper->fromResult($subscription);
         }
+
+        $this->hydrator->hydrate($subscriptions);
 
         return $subscriptions;
     }

--- a/src/Processor/Braintree/Query/SubscriptionQuery.php
+++ b/src/Processor/Braintree/Query/SubscriptionQuery.php
@@ -4,6 +4,7 @@ namespace TeamGantt\Dues\Processor\Braintree\Query;
 
 use Braintree\Gateway;
 use Braintree\SubscriptionSearch;
+use DateTimeInterface;
 use TeamGantt\Dues\Exception\InvalidSubscriptionSearchParamException;
 use TeamGantt\Dues\Model\Subscription;
 use TeamGantt\Dues\Processor\Braintree\Mapper\SubscriptionMapper;
@@ -36,6 +37,20 @@ class SubscriptionQuery
         } else {
             throw new InvalidSubscriptionSearchParamException('Comparisons can only be "<=", "=", or ">="');
         }
+
+        return $this;
+    }
+
+    public function whereNextBillingDateIs(DateTimeInterface $date): self
+    {
+        $this->searchParams['nextBillingDate'] = SubscriptionSearch::nextBillingDate()->is($date);
+
+        return $this;
+    }
+
+    public function whereSubscriptionIsPending(): self
+    {
+        $this->searchParams['status'] = SubscriptionSearch::status()->in([BraintreeSubscription::PENDING]);
 
         return $this;
     }

--- a/src/Processor/Braintree/Repository/PaymentMethodRepository.php
+++ b/src/Processor/Braintree/Repository/PaymentMethodRepository.php
@@ -35,4 +35,15 @@ class PaymentMethodRepository
 
         return $this->mapper->fromResult($result->paymentMethod);
     }
+
+    public function findByToken(string $token): ?Token
+    {
+        try {
+            $result = $this->braintree->paymentMethod()->find($token);
+
+            return $this->mapper->fromResult($result);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
 }

--- a/src/Processor/Braintree/Subscription/Update/BaseUpdateStrategy.php
+++ b/src/Processor/Braintree/Subscription/Update/BaseUpdateStrategy.php
@@ -40,7 +40,7 @@ abstract class BaseUpdateStrategy implements UpdateStrategy
     protected function doBraintreeUpdate(Subscription $subscription, ?Plan $newPlan = null)
     {
         $request = $this->mapper->toRequest($subscription, $newPlan);
-        $request = Arr::dissoc($request, ['firstBillingDate', 'status', 'statusHistory']);
+        $request = Arr::dissoc($request, ['firstBillingDate', 'nextBillingPeriodAmount', 'status', 'statusHistory']);
         $request['options'] = ['prorateCharges' => true];
 
         return $this

--- a/tests/Feature/Subscription.php
+++ b/tests/Feature/Subscription.php
@@ -57,6 +57,17 @@ trait Subscription
             ->whereNextBillingDateIs($startDate)
             ->fetch();
         $this->assertGreaterThan(0, count($pendingSubscriptions));
+
+        /**
+         * @var ModelSubscription
+         */
+        $firstPending = $pendingSubscriptions[0];
+
+        // Test the response of the query to ensure it is hydrating properly.
+        $this->assertNotEmpty($firstPending->getCustomer()->getFirstName());
+        $this->assertNotEmpty($firstPending->getCustomer()->getLastName());
+        $this->assertNotEmpty($firstPending->getCustomer()->getEmailAddress());
+        $this->assertGreaterThan(0, $firstPending->getNextBillingPeriodAmount()->getAmount());
     }
 
     /**

--- a/tests/Feature/Subscription.php
+++ b/tests/Feature/Subscription.php
@@ -49,6 +49,14 @@ trait Subscription
         $this->assertFalse($subscription->getCustomer()->isNew());
         $this->assertFalse($subscription->isNew());
         $this->assertEquals(Status::pending(), $subscription->getStatus());
+
+        // Test the query to ensure it works
+        $query = $this->dues->makeSubscriptionQuery();
+        $pendingSubscriptions = $query
+            ->whereSubscriptionIsPending()
+            ->whereNextBillingDateIs($startDate)
+            ->fetch();
+        $this->assertGreaterThan(0, count($pendingSubscriptions));
     }
 
     /**


### PR DESCRIPTION
- [ ] add query for pending subscriptions
- [ ] add query for next billing date
- [ ] add hydrator that will hydrate subscriptions with customer
  - plans was already there, but I pulled that into this hydrator
- [ ] adds `__toString()` with interface to models that need to get serialized to JSON for lumen.
- [ ] adds tests

![Screenshot_20210422_141125](https://user-images.githubusercontent.com/18272064/115765751-24de9480-a375-11eb-81de-5e3175513a6f.png)
