### PR TITLE
chore: improve hydrator performance

### DIFF
--- a/src/Processor/Braintree/Hydrator/SubscriptionHydrator.php
+++ b/src/Processor/Braintree/Hydrator/SubscriptionHydrator.php
@@ -57,7 +57,7 @@ class SubscriptionHydrator
 
                 $customer = isset($cache[$token])
                     ? $cache[$token]
-                    : $this->getCustomerBySubscriptionPaymentToken($subscription, $paymentMethod);
+                    : $this->customers->findByPaymentToken($token);
 
                 $cache[$token] = $customer;
             }
@@ -68,32 +68,6 @@ class SubscriptionHydrator
 
             $subscription->setCustomer($customer);
         }
-    }
-
-    /**
-     * Finds the customer based off of the customer id associated with the payment method and appends it back to the Subscription.
-     */
-    private function getCustomerBySubscriptionPaymentToken(Subscription $subscription, Token $paymentMethod): ?Customer
-    {
-        $customer = null;
-        $token = $paymentMethod->getValue();
-        $realPayment = $this->paymentMethods->findByToken($token);
-
-        if ($realPayment instanceof Token) {
-            $customer = $realPayment->getCustomer();
-
-            if ($customer instanceof Customer) {
-                $customerId = $customer->getId();
-                $realCustomer = $this->customers->find($customerId);
-
-                if ($realCustomer instanceof Customer) {
-                    $subscription->setCustomer($realCustomer);
-                    $customer = $realCustomer;
-                }
-            }
-        }
-
-        return $customer;
     }
 
     /**

--- a/src/Processor/Braintree/Query/SubscriptionQuery.php
+++ b/src/Processor/Braintree/Query/SubscriptionQuery.php
@@ -6,6 +6,7 @@ use Braintree\Gateway;
 use Braintree\Subscription as BraintreeSubscription;
 use Braintree\SubscriptionSearch;
 use DateTimeInterface;
+use Exception;
 use TeamGantt\Dues\Exception\InvalidSubscriptionSearchParamException;
 use TeamGantt\Dues\Model\Subscription;
 use TeamGantt\Dues\Processor\Braintree\Hydrator\SubscriptionHydrator;
@@ -58,6 +59,24 @@ class SubscriptionQuery
         $this->searchParams['status'] = SubscriptionSearch::status()->in([BraintreeSubscription::PENDING]);
 
         return $this;
+    }
+
+    public function getById(string $id): ?Subscription
+    {
+        if (empty($id)) {
+            return null;
+        }
+
+        try {
+            $find = $this->gateway->subscription()->find($id);
+
+            $subscription = $this->mapper->fromResult($find);
+            $this->hydrator->hydrate([$subscription]);
+
+            return $subscription;
+        } catch (Exception $e) {
+            return null;
+        }
     }
 
     /**

--- a/src/Processor/Braintree/Repository/CustomerRepository.php
+++ b/src/Processor/Braintree/Repository/CustomerRepository.php
@@ -3,6 +3,7 @@
 namespace TeamGantt\Dues\Processor\Braintree\Repository;
 
 use Braintree\Customer as BraintreeCustomer;
+use Braintree\CustomerSearch;
 use Braintree\Gateway;
 use Exception;
 use TeamGantt\Dues\Exception\CustomerNotCreatedException;
@@ -119,6 +120,19 @@ class CustomerRepository
     {
         if ($customerResult = $this->findBraintreeCustomer($id)) {
             return $this->mapper->fromResult($customerResult);
+        }
+
+        return null;
+    }
+
+    public function findByPaymentToken(string $tokenId): ?Customer
+    {
+        $customerResult = $this->braintree->customer()->search([
+            CustomerSearch::paymentMethodToken()->is($tokenId),
+        ]);
+
+        foreach ($customerResult as $customer) {
+            return $this->mapper->fromResult($customer);
         }
 
         return null;

--- a/tests/Feature/Subscription.php
+++ b/tests/Feature/Subscription.php
@@ -50,24 +50,13 @@ trait Subscription
         $this->assertFalse($subscription->isNew());
         $this->assertEquals(Status::pending(), $subscription->getStatus());
 
-        // Test the query to ensure it works
+        // Ensure subscriptions are hydrated properly.
         $query = $this->dues->makeSubscriptionQuery();
-        $pendingSubscriptions = $query
-            ->whereSubscriptionIsPending()
-            ->whereNextBillingDateIs($startDate)
-            ->fetch();
-        $this->assertGreaterThan(0, count($pendingSubscriptions));
-
-        /**
-         * @var ModelSubscription
-         */
-        $firstPending = $pendingSubscriptions[0];
-
-        // Test the response of the query to ensure it is hydrating properly.
-        $this->assertNotEmpty($firstPending->getCustomer()->getFirstName());
-        $this->assertNotEmpty($firstPending->getCustomer()->getLastName());
-        $this->assertNotEmpty($firstPending->getCustomer()->getEmailAddress());
-        $this->assertGreaterThan(0, $firstPending->getNextBillingPeriodAmount()->getAmount());
+        $thisSubscription = $query->getById($subscription->getId());
+        $this->assertNotEmpty($thisSubscription->getCustomer()->getFirstName());
+        $this->assertNotEmpty($thisSubscription->getCustomer()->getLastName());
+        $this->assertNotEmpty($thisSubscription->getCustomer()->getEmailAddress());
+        $this->assertGreaterThan(0, $thisSubscription->getNextBillingPeriodAmount()->getAmount());
     }
 
     /**


### PR DESCRIPTION
- The previous changes were just taking too long. Behat in the API was timing out on some of the requests (> 10 seconds).
- This changes uses the payment token to look up the customer directly through braintree search, instead of fetching the payment token, then the customer.
- So, this cuts the number of requests to hydrate from 3 to 2.
- Also added an additional query to get a subscription by id, so that the tests don't take longer based off of the amount of times you run it per day