### PR TITLE
fix: subscription update with defaults

### DIFF
--- a/src/Processor/Braintree/Mapper/Subscription/ModifierMapper.php
+++ b/src/Processor/Braintree/Mapper/Subscription/ModifierMapper.php
@@ -54,10 +54,13 @@ class ModifierMapper
                 $default = Arr::replaceKeys($newDefault->toArray(), ['id' => 'inheritedFromId']);
 
                 if (is_array($modifiers)) {
-                    // if new modifier is in default, merge modifiers
-                    $userSuppliedModifiers = Arr::filter($modifiers, fn ($modifier) => $modifier['inheritedFromId'] !== $default['inheritedFromId']);
+                    $otherUserSuppliedModifiers = Arr::filter($modifiers, fn ($modifier) => $modifier['inheritedFromId'] !== $default['inheritedFromId']);
+                    $defaultModifierWithProvidedUpdates = [array_merge(
+                        $default,
+                        ...Arr::filter($modifiers, fn ($modifier) => $modifier['inheritedFromId'] === $default['inheritedFromId']) ?? []
+                    )];
 
-                    return [...$userSuppliedModifiers, $default];
+                    return array_merge($otherUserSuppliedModifiers, $defaultModifierWithProvidedUpdates);
                 }
 
                 return [$default];


### PR DESCRIPTION
# Checks & Balances
![Screenshot_20210622_084354](https://user-images.githubusercontent.com/18272064/122926661-19d4c000-d336-11eb-83f1-47030995a995.png)

# The Issue
- We found case where if a user was upgrading from one plan to another (and staying on the same billing cycle) the quantity provided by the user would not be respected and inherit from the default, thus setting the quantity to 1... regardless of what the user provided. :scream: 

# Steps to Reproduce
- Manual
    - [ ] in the context of TG staging
    - [ ] signup for a new subscription
    - [ ] purchase the standard plan with 8 users
    - [ ] upgraded from the standard plan to the advanced plan with 8 users as well
- Automated
    - [ ] checkout the first commit of this PR & run `composer test -- --filter testSubscriptionUpgradeCrossPlanWithUpdateToDefaultAddOns`

# Expected
- you were upgraded to the advanced with 8 users

# Actual
- you were upgraded to the advanced plan, but the users was set to 1 :scream: 