### PR TITLE
fix(cycle-changes): handle rollover when coming from yearly

### DIFF
--- a/src/Exception/BillingPeriodCycleException.php
+++ b/src/Exception/BillingPeriodCycleException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace TeamGantt\Dues\Exception;
+
+use RuntimeException;
+
+class BillingPeriodCycleException extends RuntimeException
+{
+}

--- a/src/Model/Subscription/BillingPeriod.php
+++ b/src/Model/Subscription/BillingPeriod.php
@@ -3,6 +3,7 @@
 namespace TeamGantt\Dues\Model\Subscription;
 
 use DateTime;
+use TeamGantt\Dues\Exception\BillingPeriodCycleException;
 
 class BillingPeriod
 {
@@ -32,7 +33,13 @@ class BillingPeriod
      */
     public function getBillingCycle(): int
     {
-        return $this->getStartDate()->diff($this->getEndDate())->d;
+        $days = $this->getStartDate()->diff($this->getEndDate())->days;
+
+        if (false === $days) {
+            throw new BillingPeriodCycleException('Unable to determine the number of days in the billing cycle.');
+        }
+
+        return $days;
     }
 
     /**
@@ -42,7 +49,12 @@ class BillingPeriod
     public function getRemainingBillingCycle(): int
     {
         $today = new DateTime('UTC');
+        $remainingDays = $today->diff($this->getEndDate())->days;
 
-        return $today->diff($this->getEndDate())->d;
+        if (false === $remainingDays) {
+            throw new BillingPeriodCycleException('Unable to determine the number of days remaining in the current billing cycle.');
+        }
+
+        return $remainingDays;
     }
 }


### PR DESCRIPTION
I should have caught this in code review...

```php
$today->diff($this->getEndDate())->d; // returns just the days in a year/month/day breakdown
$today->diff($this->getEndDate())->days; // returns the total number of days in the difference
```
https://www.php.net/manual/en/function.date-diff.php#126177
https://stackoverflow.com/a/3923228

This does have a chance to return `false` if it is unable to determine the difference in days, so handling that & throwing an exception.