### PR TITLE
feat: add support for street address

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,3 +15,4 @@ parameters:
     - stubs/Braintree/Subscription.stub
     - stubs/Braintree/Subscription/StatusDetails.stub
     - stubs/Braintree/Transaction.stub
+    - stubs/Braintree/Transaction/AddressDetails.stub

--- a/src/Model/Address.php
+++ b/src/Model/Address.php
@@ -14,11 +14,18 @@ class Address implements Arrayable
 
     protected ?Country $country = null;
 
-    public function __construct(?State $state = null, ?string $postalCode = null, ?Country $country = null)
+    protected ?string $streetAddress = null;
+
+    public function __construct(
+        ?State $state = null,
+        ?string $postalCode = null,
+        ?Country $country = null,
+        ?string $streetAddress = null)
     {
         $this->state = $state;
         $this->postalCode = $postalCode;
         $this->country = $country;
+        $this->streetAddress = $streetAddress;
     }
 
     public function getPostalCode(): ?string
@@ -36,12 +43,18 @@ class Address implements Arrayable
         return $this->country;
     }
 
+    public function getStreetAddress(): ?string
+    {
+        return $this->streetAddress;
+    }
+
     public function toArray(): array
     {
         return array_filter([
             'postalCode' => $this->postalCode,
             'state' => isset($this->state) ? $this->state->value : null,
             'country' => isset($this->country) ? $this->country : null,
+            'streetAddress' => $this->streetAddress,
         ]);
     }
 }

--- a/src/Model/Transaction.php
+++ b/src/Model/Transaction.php
@@ -38,6 +38,8 @@ class Transaction extends Entity
 
     protected ?PayPalDetails $payPalDetails = null;
 
+    protected ?Address $billingDetails = null;
+
     public function __construct(string $id = '', ?Subscription $subscription = null)
     {
         parent::__construct($id);
@@ -76,6 +78,18 @@ class Transaction extends Entity
     public function setStatus(Status $status): self
     {
         $this->status = $status;
+
+        return $this;
+    }
+
+    public function getBillingDetails(): ?Address
+    {
+        return $this->billingDetails;
+    }
+
+    public function setBillingDetails(Address $details): self
+    {
+        $this->billingDetails = $details;
 
         return $this;
     }

--- a/src/Processor/Braintree/Mapper/MapsAddresses.php
+++ b/src/Processor/Braintree/Mapper/MapsAddresses.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace TeamGantt\Dues\Processor\Braintree\Mapper;
+
+use Braintree\Address as BraintreeAddress;
+use Braintree\Transaction\AddressDetails;
+use TeamGantt\Dues\Model\Address;
+use TeamGantt\Dues\Model\Address\Country;
+use TeamGantt\Dues\Model\Address\State;
+use Throwable;
+
+trait MapsAddresses
+{
+    /**
+     * @param BraintreeAddress|AddressDetails $braintreeAddress
+     */
+    protected function toAddress($braintreeAddress): Address
+    {
+        $state = $this->getStateFromAddress($braintreeAddress);
+        $country = $this->getCountryFromAddress($braintreeAddress);
+        $postalCode = $braintreeAddress->postalCode;
+        $streetAddress = $braintreeAddress->streetAddress;
+
+        return new Address($state, $postalCode, $country, $streetAddress);
+    }
+
+    /**
+     * @param BraintreeAddress|AddressDetails $braintreeAddress
+     */
+    protected function getStateFromAddress($braintreeAddress): ?State
+    {
+        try {
+            return new State($braintreeAddress->region);
+        } catch (Throwable $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param BraintreeAddress|AddressDetails $braintreeAddress
+     */
+    protected function getCountryFromAddress($braintreeAddress): ?Country
+    {
+        try {
+            // countryCodeAlpha2 exists but is not documented on the BraintreeAddress
+            return new Country($braintreeAddress->countryCodeAlpha2); // @phpstan-ignore-line
+        } catch (Throwable $e) {
+            return null;
+        }
+    }
+}

--- a/src/Processor/Braintree/Mapper/PaymentMethodMapper.php
+++ b/src/Processor/Braintree/Mapper/PaymentMethodMapper.php
@@ -8,17 +8,15 @@ use DateTime;
 use DateTimeImmutable;
 use InvalidArgumentException;
 use TeamGantt\Dues\Arr;
-use TeamGantt\Dues\Model\Address;
-use TeamGantt\Dues\Model\Address\Country;
-use TeamGantt\Dues\Model\Address\State;
 use TeamGantt\Dues\Model\Customer;
 use TeamGantt\Dues\Model\PaymentMethod;
 use TeamGantt\Dues\Model\PaymentMethod\Nonce;
 use TeamGantt\Dues\Model\PaymentMethod\Token;
-use Throwable;
 
 class PaymentMethodMapper
 {
+    use MapsAddresses;
+
     /**
      * @return mixed[]
      *
@@ -79,31 +77,10 @@ class PaymentMethodMapper
 
         $billingAddress = $paymentMethod->billingAddress;
         if ($billingAddress instanceof BraintreeAddress) {
-            $state = $this->getStateFromAddress($billingAddress);
-            $country = $this->getCountryFromAddress($billingAddress);
-
-            $token->setBillingAddress(new Address($state, $billingAddress->postalCode, $country));
+            $address = $this->toAddress($billingAddress);
+            $token->setBillingAddress($address);
         }
 
         return $token;
-    }
-
-    protected function getStateFromAddress(BraintreeAddress $address): ?State
-    {
-        try {
-            return new State($address->region);
-        } catch (Throwable $e) {
-            return null;
-        }
-    }
-
-    protected function getCountryFromAddress(BraintreeAddress $address): ?Country
-    {
-        try {
-            // countryCodeAlpha2 exists but is not documented on the BraintreeAddress
-            return new Country($address->countryCodeAlpha2); // @phpstan-ignore-line
-        } catch (Throwable $e) {
-            return null;
-        }
     }
 }

--- a/src/Processor/Braintree/Mapper/TransactionMapper.php
+++ b/src/Processor/Braintree/Mapper/TransactionMapper.php
@@ -4,6 +4,7 @@ namespace TeamGantt\Dues\Processor\Braintree\Mapper;
 
 use Braintree\PaymentInstrumentType as BraintreePaymentInstrumentType;
 use Braintree\Transaction as BraintreeTransaction;
+use TeamGantt\Dues\Model\Address;
 use TeamGantt\Dues\Model\CreditCardType;
 use TeamGantt\Dues\Model\Customer;
 use TeamGantt\Dues\Model\Money;
@@ -19,6 +20,8 @@ use TeamGantt\Dues\Model\Transaction\Type;
 
 class TransactionMapper
 {
+    use MapsAddresses;
+
     private AddOnMapper $addOnMapper;
 
     private DiscountMapper $discountMapper;
@@ -45,9 +48,20 @@ class TransactionMapper
             ->setType($this->getType($result))
             ->setPaymentInstrumentType($this->getPaymentInstrumentType($result));
 
+        if (isset($result->billingDetails)) {
+            $transaction->setBillingDetails($this->getBillingDetails($result));
+        }
+
         $this->setPaymentInstrument($transaction, $result);
 
         return $transaction;
+    }
+
+    private function getBillingDetails(BraintreeTransaction $result): Address
+    {
+        $address = $result->billingDetails;
+
+        return $this->toAddress($address);
     }
 
     private function setPaymentInstrument(Transaction $transaction, BraintreeTransaction $result): void

--- a/stubs/Braintree/Transaction.stub
+++ b/stubs/Braintree/Transaction.stub
@@ -15,6 +15,7 @@ namespace Braintree;
  * @property \Braintree\Customer $customerDetails
  * @property string $type
  * @property string $status
+ * @property \Braintree\Transaction\AddressDetails $billingDetails
  */
 class Transaction
 {

--- a/stubs/Braintree/Transaction/AddressDetails.stub
+++ b/stubs/Braintree/Transaction/AddressDetails.stub
@@ -1,12 +1,12 @@
 <?php
 
-namespace Braintree;
+namespace Braintree\Transaction;
 
 /**
  * @property string $postalCode
  * @property string $region
  * @property string $streetAddress
  */
-class Address
+class AddressDetails
 {
 }

--- a/tests/Feature/Transaction.php
+++ b/tests/Feature/Transaction.php
@@ -12,6 +12,7 @@ trait Transaction
 
     /**
      * @group integration
+     * @group transactions
      * @dataProvider subscriptionProvider
      *
      * @return void
@@ -28,6 +29,7 @@ trait Transaction
 
     /**
      * @group integration
+     * @group transactions
      * @dataProvider subscriptionProvider
      *
      * @return void
@@ -45,6 +47,7 @@ trait Transaction
 
     /**
      * @group integration
+     * @group transactions
      * @dataProvider subscriptionProvider
      *
      * @return void
@@ -67,6 +70,7 @@ trait Transaction
 
     /**
      * @group integration
+     * @group transactions
      * @dataProvider subscriptionProvider
      *
      * @return void
@@ -89,6 +93,7 @@ trait Transaction
 
     /**
      * @group integration
+     * @group transactions
      * @dataProvider subscriptionProvider
      *
      * @return void


### PR DESCRIPTION
Part of [#113366813](https://app.teamgantt.com/boards/3a9359e5-68ae-4134-b365-9b36b3d6c8d9/edit/113366813)

Unifies address details for payment methods and transactions. Adds street address to the Dues `Address` type. 