### PR TITLE
fix(subscription): get correct remaining value

### DIFF
--- a/src/Model/Modifier/Modifier.php
+++ b/src/Model/Modifier/Modifier.php
@@ -15,6 +15,8 @@ abstract class Modifier extends Entity implements Arrayable, Valuable
 
     protected ?int $quantity = null;
 
+    protected bool $isExpired = false;
+
     public function __construct(string $id = '', ?int $quantity = null, ?Price $price = null)
     {
         parent::__construct($id);
@@ -25,6 +27,18 @@ abstract class Modifier extends Entity implements Arrayable, Valuable
     public function getPrice(): ?Price
     {
         return $this->price;
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->isExpired;
+    }
+
+    public function setIsExpired(bool $isExpired): Modifier
+    {
+        $this->isExpired = $isExpired;
+
+        return $this;
     }
 
     public function setPrice(Price $price): Modifier

--- a/src/Model/Modifier/ModifierBuilder.php
+++ b/src/Model/Modifier/ModifierBuilder.php
@@ -23,6 +23,11 @@ abstract class ModifierBuilder extends Builder
         return $this->with('price', $price);
     }
 
+    public function withIsExpired(bool $isExpired): self
+    {
+        return $this->with('isExpired', $isExpired);
+    }
+
     protected function buildModifier(Modifier $modifier): void
     {
         if (isset($this->data['quantity'])) {
@@ -30,6 +35,7 @@ abstract class ModifierBuilder extends Builder
         }
 
         $modifier->setPrice($this->data['price'] ?? new NullPrice());
+        $modifier->setIsExpired($this->data['isExpired'] ?? false);
 
         $this->reset();
     }

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -201,6 +201,10 @@ class Subscription extends Entity implements Arrayable, Valuable
         }
 
         $priceReducer = function (float $value, Modifier $mod) {
+            if (true === $mod->isExpired()) {
+                return $value;
+            }
+
             return $value + $mod->getValue()->getAmount();
         };
 

--- a/src/Model/Subscription/BillingPeriod.php
+++ b/src/Model/Subscription/BillingPeriod.php
@@ -3,26 +3,27 @@
 namespace TeamGantt\Dues\Model\Subscription;
 
 use DateTime;
+use DateTimeInterface;
 use TeamGantt\Dues\Exception\BillingPeriodCycleException;
 
 class BillingPeriod
 {
-    protected DateTime $startDate;
+    protected DateTimeInterface $startDate;
 
-    protected DateTime $endDate;
+    protected DateTimeInterface $endDate;
 
-    public function __construct(DateTime $startDate, DateTime $endDate)
+    public function __construct(DateTimeInterface $startDate, DateTimeInterface $endDate)
     {
         $this->startDate = $startDate;
         $this->endDate = $endDate;
     }
 
-    public function getEndDate(): DateTime
+    public function getEndDate(): DateTimeInterface
     {
         return $this->endDate;
     }
 
-    public function getStartDate(): DateTime
+    public function getStartDate(): DateTimeInterface
     {
         return $this->startDate;
     }

--- a/src/Processor/Braintree/Mapper/MapsModifiers.php
+++ b/src/Processor/Braintree/Mapper/MapsModifiers.php
@@ -18,8 +18,15 @@ trait MapsModifiers
             $builder->withQuantity($result->quantity);
         }
 
+        $neverExpires = isset($result->neverExpires) ? $result->neverExpires : true;
+        $numberOfBillingCycles = isset($result->numberOfBillingCycles) ? $result->numberOfBillingCycles : INF;
+        $currentBillingCycle = isset($result->currentBillingCycle) ? $result->currentBillingCycle : 1;
+
+        $isExpired = !$neverExpires && $currentBillingCycle >= $numberOfBillingCycles;
+
         $builder
             ->withId($result->id)
-            ->withPrice(new Price(floatval($result->amount)));
+            ->withPrice(new Price(floatval($result->amount)))
+            ->withIsExpired($isExpired);
     }
 }

--- a/stubs/Braintree/AddOn.stub
+++ b/stubs/Braintree/AddOn.stub
@@ -5,6 +5,9 @@ namespace Braintree;
 /**
  * @property string $id
  * @property float $amount
+ * @property int $currentBillingCycle
+ * @property bool $neverExpires
+ * @property ?int $numberOfBillingCycles
  */
 class AddOn
 {

--- a/stubs/Braintree/Discount.stub
+++ b/stubs/Braintree/Discount.stub
@@ -5,6 +5,9 @@ namespace Braintree;
 /**
  * @property string $id
  * @property float $amount
+ * @property int $currentBillingCycle
+ * @property bool $neverExpires
+ * @property ?int $numberOfBillingCycles
  */
 class Discount
 {


### PR DESCRIPTION
This tackles a few issues @ismyrnow and I saw when working with this on the front end.

1. Expired modifiers (addons/discounts) should not count towards the subscription's value
2. Billing cycle days should count the start date and today when calculating the range. (all calculations were one day short)

Also `calculateRemainingValue` was extracted from `src/Processor/Braintree/Mapper/SubscriptionMapper.php` to make it more testable. We cannot replace the internals of `->getRemainingValue()` to use this calculation as it works off of the current property values on the Subscription. In the case of switching a subscription to another plan/cycle/etc, the values required are already changed upstream and when ran, it produces an incorrect. This change seemed like the most pragmatic approach.