### PR TITLE
feat: next billing date

### DIFF
--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -48,6 +48,8 @@ class Subscription extends Entity implements Arrayable, Valuable
 
     protected ?Money $nextBillingPeriodAmount;
 
+    protected ?\DateTimeInterface $nextBillingDate;
+
     protected bool $isProrated = true;
 
     /**
@@ -90,6 +92,7 @@ class Subscription extends Entity implements Arrayable, Valuable
                 'payment' => empty($payment) ? null : $payment->toArray(),
                 'plan' => $this->plan->toArray(),
                 'nextBillingPeriodAmount' => $this->getNextBillingPeriodAmount(),
+                'nextBillingDate' => $this->getNextBillingDate(),
             ]),
             [
                 'isProrated' => $this->isProrated(),
@@ -553,6 +556,26 @@ class Subscription extends Entity implements Arrayable, Valuable
     public function setNextBillingPeriodAmount(Money $amount): self
     {
         $this->nextBillingPeriodAmount = $amount;
+
+        return $this;
+    }
+
+    public function getNextBillingDate(): ?\DateTimeInterface
+    {
+        if ($this->is(Status::canceled())) {
+            return null;
+        }
+
+        if (isset($this->nextBillingDate)) {
+            return $this->nextBillingDate;
+        }
+
+        return null;
+    }
+
+    public function setNextBillingDate(?\DateTimeInterface $date): self
+    {
+        $this->nextBillingDate = $date;
 
         return $this;
     }

--- a/src/Model/Subscription/SubscriptionBuilder.php
+++ b/src/Model/Subscription/SubscriptionBuilder.php
@@ -122,6 +122,11 @@ class SubscriptionBuilder extends Builder
         return $this->with('nextBillingPeriodAmount', $amount);
     }
 
+    public function withNextBillingDate(\DateTimeInterface $nextBillingDate): self
+    {
+        return $this->with('nextBillingDate', $nextBillingDate);
+    }
+
     public function build(): Subscription
     {
         $subscription = (new Subscription($this->getId()))
@@ -144,6 +149,10 @@ class SubscriptionBuilder extends Builder
 
         if (isset($this->data['nextBillingPeriodAmount'])) {
             $subscription->setNextBillingPeriodAmount($this->data['nextBillingPeriodAmount']);
+        }
+
+        if (isset($this->data['nextBillingDate'])) {
+            $subscription->setNextBillingDate($this->data['nextBillingDate']);
         }
 
         if (isset($this->data['billingPeriod'])) {

--- a/src/Processor/Braintree/Mapper/SubscriptionMapper.php
+++ b/src/Processor/Braintree/Mapper/SubscriptionMapper.php
@@ -54,7 +54,7 @@ class SubscriptionMapper
 
         $request['options'] = ['prorateCharges' => $request['isProrated']];
 
-        $request = Arr::dissoc($request, ['customer', 'daysPastDue', 'isProrated']);
+        $request = Arr::dissoc($request, ['customer', 'daysPastDue', 'isProrated', 'nextBillingDate']);
 
         $request = Arr::updateIn($request, [], function (array $r) {
             if (isset($r['paymentMethodToken']['token'])) {
@@ -111,6 +111,7 @@ class SubscriptionMapper
 
         $billingPeriodStart = $result->billingPeriodStartDate;
         $billingPeriodEnd = $result->billingPeriodEndDate;
+        $nextBillingDate = $result->nextBillingDate;
 
         $subscription = $builder
             ->withId($result->id)
@@ -122,6 +123,7 @@ class SubscriptionMapper
             ->withDaysPastDue($daysPastDue)
             ->withPaymentMethod($paymentMethod)
             ->withBillingPeriod($billingPeriodStart, $billingPeriodEnd)
+            ->withNextBillingDate($nextBillingDate)
             ->withPlan($plan);
 
         if (isset($result->nextBillingPeriodAmount)) {

--- a/stubs/Braintree/Subscription.stub
+++ b/stubs/Braintree/Subscription.stub
@@ -18,6 +18,7 @@ namespace Braintree;
  * @property string $paymentMethodToken
  * @property array $statusHistory
  * @property float $nextBillingPeriodAmount
+ * @property \DateTimeInterface $nextBillingDate
  */
 class Subscription
 {

--- a/tests/Feature/Customer.php
+++ b/tests/Feature/Customer.php
@@ -259,7 +259,7 @@ trait Customer
      *
      * @return void
      */
-    public function testChangePaymentMethodToExistingPaymentMethodWithCancelledSubscriptions(callable $subscriptionFactory)
+    public function testChangePaymentMethodToExistingPaymentMethodWithCanceledSubscriptions(callable $subscriptionFactory)
     {
         $subscription = $subscriptionFactory($this->dues);
         $customer = $subscription->getCustomer();

--- a/tests/Feature/Subscription.php
+++ b/tests/Feature/Subscription.php
@@ -464,7 +464,7 @@ trait Subscription
         $this->assertTrue($subscription->is(Status::canceled()));
 
         $rollover = $subscription->getRemainingValue()->getAmount();
-        $this->assertEquals($rollover, 1726.83);
+        $this->assertEqualsWithDelta(1726.83, $rollover, 0.3);
     }
 
     /**

--- a/tests/Feature/Subscription.php
+++ b/tests/Feature/Subscription.php
@@ -122,6 +122,88 @@ trait Subscription
      *
      * @return void
      */
+    public function testVerifyNextBillingDate(callable $customerFactory)
+    {
+        $customer = $customerFactory($this->dues);
+        $plan = $this->dues->findPlanById('test-plan-c-monthly');
+        $today = new \DateTime('now', new \DateTimeZone('UTC'));
+        $nextBillingDate = $today->modify('+1 month');
+
+        $subscription = (new SubscriptionBuilder())
+            ->withCustomer($customer)
+            ->withPlan($plan)
+            ->build();
+
+        /**
+         * @var ModelSubscription
+         */
+        $subscription = $this->dues->createSubscription($subscription);
+
+        $this->assertEquals($nextBillingDate->format('Y-m-d'), $subscription->getNextBillingDate()->format('Y-m-d'));
+    }
+
+    /**
+     * @group integration
+     *
+     * @dataProvider customerProvider
+     *
+     * @return void
+     */
+    public function testVerifyNextBillingDateWithFutureStartDate(callable $customerFactory)
+    {
+        $customer = $customerFactory($this->dues);
+        $plan = $this->dues->findPlanById('test-plan-c-monthly');
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+        $startDate = $now->add(new \DateInterval('P1D')); // start 1 day in the future
+
+        $subscription = (new SubscriptionBuilder())
+            ->withCustomer($customer)
+            ->withPlan($plan)
+            ->withStartDate($startDate)
+            ->build();
+
+        /**
+         * @var ModelSubscription
+         */
+        $subscription = $this->dues->createSubscription($subscription);
+
+        $this->assertEquals($startDate->format('Y-m-d'), $subscription->getNextBillingDate()->format('Y-m-d'));
+    }
+
+    /**
+     * @group integration
+     *
+     * @dataProvider customerProvider
+     *
+     * @return void
+     */
+    public function testVerifyNextBillingDateOnCanceledSubscription(callable $customerFactory)
+    {
+        $customer = $customerFactory($this->dues);
+        $plan = $this->dues->findPlanById('test-plan-c-monthly');
+
+        $subscription = (new SubscriptionBuilder())
+            ->withCustomer($customer)
+            ->withPlan($plan)
+            ->build();
+
+        /**
+         * @var ModelSubscription
+         */
+        $subscription = $this->dues->createSubscription($subscription);
+
+        $canceled = $this->dues->cancelSubscription($subscription->getId());
+
+        $this->assertNull($canceled->getNextBillingDate());
+    }
+
+    /**
+     * @group integration
+     *
+     * @dataProvider customerProvider
+     *
+     * @return void
+     */
     public function testCreateSubscriptionWithListener(callable $customerFactory)
     {
         $customer = $customerFactory($this->dues);

--- a/tests/Model/SubscriptionTest.php
+++ b/tests/Model/SubscriptionTest.php
@@ -10,12 +10,12 @@ final class SubscriptionTest extends TestCase
 {
     public function testIsNotStatus()
     {
-        $cancelled = new Subscription();
-        $cancelled->setStatus(Status::canceled());
+        $canceled = new Subscription();
+        $canceled->setStatus(Status::canceled());
         $active = new Subscription();
         $active->setStatus(Status::active());
 
-        $this->assertTrue($cancelled->isNot(Status::active()));
+        $this->assertTrue($canceled->isNot(Status::active()));
         $this->assertFalse($active->isNot(Status::active()));
     }
 }


### PR DESCRIPTION
Adding `nextBillingDate` data from Braintree to our system. This info is now necessary on the front end.