### PR TITLE
feat: add support for trial periods

### DIFF
--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -15,6 +15,7 @@ use TeamGantt\Dues\Model\Subscription\Modifier\OperationType;
 use TeamGantt\Dues\Model\Subscription\Modifiers;
 use TeamGantt\Dues\Model\Subscription\Status;
 use TeamGantt\Dues\Model\Subscription\StatusHistory;
+use TeamGantt\Dues\Model\Subscription\Trial\Trial;
 
 class Subscription extends Entity implements Arrayable, Valuable
 {
@@ -52,6 +53,8 @@ class Subscription extends Entity implements Arrayable, Valuable
 
     protected bool $isProrated = true;
 
+    protected Trial $trial;
+
     /**
      * @var StatusHistory[]
      */
@@ -84,6 +87,7 @@ class Subscription extends Entity implements Arrayable, Valuable
             array_filter([
                 'id' => $this->getId(),
                 'startDate' => $this->getStartDate(),
+                'trial' => $this->getTrial()?->toArray(),
                 'price' => empty($price) ? null : $price->toArray(),
                 'status' => $this->getStatus(),
                 'statusHistory' => $this->getStatusHistory(),
@@ -595,6 +599,22 @@ class Subscription extends Entity implements Arrayable, Valuable
     public function isProrated(): bool
     {
         return $this->isProrated;
+    }
+
+    public function setTrial(Trial $trial): self
+    {
+        $this->trial = $trial;
+
+        return $this;
+    }
+
+    public function getTrial(): ?Trial
+    {
+        if (isset($this->trial)) {
+            return $this->trial;
+        }
+
+        return null;
     }
 
     /**

--- a/src/Model/Subscription/SubscriptionBuilder.php
+++ b/src/Model/Subscription/SubscriptionBuilder.php
@@ -14,6 +14,7 @@ use TeamGantt\Dues\Model\Plan\NullPlan;
 use TeamGantt\Dues\Model\Price;
 use TeamGantt\Dues\Model\Price\NullPrice;
 use TeamGantt\Dues\Model\Subscription;
+use TeamGantt\Dues\Model\Subscription\Trial\Trial;
 
 class SubscriptionBuilder extends Builder
 {
@@ -127,6 +128,11 @@ class SubscriptionBuilder extends Builder
         return $this->with('nextBillingDate', $nextBillingDate);
     }
 
+    public function withTrial(Trial $trial): self
+    {
+        return $this->with('trial', $trial);
+    }
+
     public function build(): Subscription
     {
         $subscription = (new Subscription($this->getId()))
@@ -137,6 +143,10 @@ class SubscriptionBuilder extends Builder
 
         if (isset($this->data['startDate'])) {
             $subscription->setStartDate($this->data['startDate']);
+        }
+
+        if (isset($this->data['trial'])) {
+            $subscription->setTrial($this->data['trial']);
         }
 
         if (isset($this->data['paymentMethod'])) {

--- a/src/Model/Subscription/Trial/Trial.php
+++ b/src/Model/Subscription/Trial/Trial.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TeamGantt\Dues\Model\Subscription\Trial;
+
+/**
+ * The number of days a trial period should be.
+ */
+class Trial
+{
+    protected readonly int $timeframe;
+    protected readonly TrialUnit $unit;
+
+    public function __construct(int $timeframe, TrialUnit $unit)
+    {
+        $this->timeframe = $timeframe;
+        $this->unit = $unit;
+    }
+
+    public function getTimeframe(): int
+    {
+        return $this->timeframe;
+    }
+
+    public function getUnit(): TrialUnit
+    {
+        return $this->unit;
+    }
+
+    /**
+     * @return array{'timeframe': int, 'unit': TrialUnit}
+     */
+    public function toArray(): array
+    {
+        return [
+            'timeframe' => $this->getTimeframe(),
+            'unit' => $this->getUnit(),
+        ];
+    }
+}

--- a/src/Model/Subscription/Trial/TrialUnit.php
+++ b/src/Model/Subscription/Trial/TrialUnit.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace TeamGantt\Dues\Model\Subscription\Trial;
+
+use Spatie\Enum\Enum;
+
+/**
+ * @method static self day()
+ * @method static self week()
+ */
+class TrialUnit extends Enum
+{
+}

--- a/src/Processor/Braintree/Subscription/Update/BaseUpdateStrategy.php
+++ b/src/Processor/Braintree/Subscription/Update/BaseUpdateStrategy.php
@@ -40,11 +40,29 @@ abstract class BaseUpdateStrategy implements UpdateStrategy
     protected function doBraintreeUpdate(Subscription $subscription, ?Plan $newPlan = null)
     {
         $request = $this->mapper->toRequest($subscription, $newPlan);
-        $request = Arr::dissoc($request, ['firstBillingDate', 'nextBillingPeriodAmount', 'status', 'statusHistory']);
+        $request = Arr::dissoc($request, $this->invalidUpdateKeys());
 
         return $this
             ->braintree
             ->subscription()
             ->update($request['id'], $request);
+    }
+
+    /**
+     * Keys that braintree does not allow to be updated.
+     *
+     * @return array<string>
+     */
+    protected function invalidUpdateKeys(): array
+    {
+        return [
+            'firstBillingDate',
+            'nextBillingPeriodAmount',
+            'status',
+            'statusHistory',
+            'trialDuration',
+            'trialDurationUnit',
+            'trialPeriod',
+        ];
     }
 }

--- a/stubs/Braintree/Subscription.stub
+++ b/stubs/Braintree/Subscription.stub
@@ -2,6 +2,8 @@
 
 namespace Braintree;
 
+use TeamGantt\Dues\Model\Subscription\Trial\TrialUnit;
+
 /**
  * @property int $daysPastDue
  * @property array $addOns
@@ -19,6 +21,9 @@ namespace Braintree;
  * @property array $statusHistory
  * @property float $nextBillingPeriodAmount
  * @property \DateTimeInterface $nextBillingDate
+ * @property int $trialDuration
+ * @property TrialUnit $trialDurationUnit
+ * @property bool $trialPeriod
  */
 class Subscription
 {


### PR DESCRIPTION
- Adds support for the Trial Period in Braintree.
- Prevents a user from supplying both a future start date and a trial period, they must pick one or the other
- Preserves the trial period when migrating from one billing cycle to another
- Allows modifications to a subscription in trial without changing the trial period
  - ie: trial period can only be defined when creating the subscription.
- Has tests