### PR TITLE
chore(braintree-retry): increase the time between retries and add 4th attempt

### DIFF
--- a/src/Processor/Braintree/Hydrator/SubscriptionHydrator.php
+++ b/src/Processor/Braintree/Hydrator/SubscriptionHydrator.php
@@ -117,7 +117,7 @@ class SubscriptionHydrator
         /**
          * Number of seconds to delay before retrying a request.
          */
-        $backoff = [2, 4, 16];
+        $backoff = [4, 8, 16, 32];
 
         try {
             return call_user_func($fn);


### PR DESCRIPTION
Still see a handful of failures on our automated scripts, adding more delay between backoff, and a 4th attempt... hopefully this will suffice.